### PR TITLE
Add links from apps/gnome-disks to apps/palimpsest

### DIFF
--- a/usr/share/icons/Mint-X/apps/16/gnome-disks.png
+++ b/usr/share/icons/Mint-X/apps/16/gnome-disks.png
@@ -1,0 +1,1 @@
+palimpsest.png

--- a/usr/share/icons/Mint-X/apps/22/gnome-disks.png
+++ b/usr/share/icons/Mint-X/apps/22/gnome-disks.png
@@ -1,0 +1,1 @@
+palimpsest.png

--- a/usr/share/icons/Mint-X/apps/24/gnome-disks.png
+++ b/usr/share/icons/Mint-X/apps/24/gnome-disks.png
@@ -1,0 +1,1 @@
+palimpsest.png

--- a/usr/share/icons/Mint-X/apps/32/gnome-disks.png
+++ b/usr/share/icons/Mint-X/apps/32/gnome-disks.png
@@ -1,0 +1,1 @@
+palimpsest.png

--- a/usr/share/icons/Mint-X/apps/48/gnome-disks.png
+++ b/usr/share/icons/Mint-X/apps/48/gnome-disks.png
@@ -1,0 +1,1 @@
+palimpsest.png

--- a/usr/share/icons/Mint-X/apps/scalable/gnome-disks.svg
+++ b/usr/share/icons/Mint-X/apps/scalable/gnome-disks.svg
@@ -1,0 +1,1 @@
+palimpsest.svg


### PR DESCRIPTION
Link gnome-disks to palimpsest. On my fresh Mint 17 system, gnome-disks is falling back to hicolor.
