### PR TITLE
Added media-playlist-repeat-song-symbolic.svg

### DIFF
--- a/usr/share/icons/Mint-X/status/scalable/media-playlist-repeat-song-symbolic.svg
+++ b/usr/share/icons/Mint-X/status/scalable/media-playlist-repeat-song-symbolic.svg
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   version="1.1"
+   width="16"
+   height="16"
+   id="svg2">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <path
+     d="m 1,9 0,1.5 C 1,11.885 2.115,13 3.5,13 l 1.5312,0 C 5.0208,12.922 5,12.862 5,12.781 L 5,11 4.5,11 C 3.669,11 3,10.331 3,9.5 L 3,9 z"
+     id="path4"
+     style="fill:#bebebe" />
+  <path
+     d="M 3.9688003,0.0404 C 1.7769,0.0404 0,1.8173 0,4.0092 0,6.2011 1.7769,7.978 3.9688003,7.978 c 2.1919,0 3.9688,-1.7769 3.9688,-3.9688 0,-2.1919 -1.7769,-3.9688 -3.9688,-3.9688 z m -0.99626,1.8955 h 2.0035 v 4.0334 h -2.0035 V 4.0205 L 1.97254,4.0562 V 2.9359 z"
+     id="path8290"
+     style="color:#000000;fill:#bebebe" />
+  <path
+     d="m 9,3 0,2 2.5,0 C 12.331,5 13,5.669 13,6.5 l 0,3 c 0,0.831 -0.669,1.5 -1.5,1.5 l -0.5,0 0,-2 -4,3 4,3 0,-2 1.5,0 c 1.385,0 2.5,-1.115 2.5,-2.5 l 0,-5 C 15,4.115 13.885,3 12.5,3 z"
+     id="path4-5"
+     style="fill:#bebebe" />
+</svg>


### PR DESCRIPTION
As the sound applet uses this icon now and I found a little difference between the gnome `media-playlist-repeat-song`, which is used, and the mint `media-playlist-repeat` in the arrow, I thought I just add this file, as the difference is slightly visible.

*******

gnome `media-playlist-repeat-song`:
![gnome-media-playlist-repeat-song-symbolic](https://cloud.githubusercontent.com/assets/7093655/7866824/32dc461a-0572-11e5-85a8-d6e0295064b6.png)

mint `media-playlist-repeat`:
![mint-media-playlist-repeat-symbolic](https://cloud.githubusercontent.com/assets/7093655/7866835/4df0c318-0572-11e5-800e-8d1d98238519.png)

*******

If you're unhappy with the output (e.g. no enough compressed), just tell me how to achieve it.