### PR TITLE
Ups icons support

### DIFF
--- a/usr/share/icons/Mint-X/index.theme
+++ b/usr/share/icons/Mint-X/index.theme
@@ -2,7 +2,7 @@
 Name=Mint-X
 Inherits=gnome,ubuntu-mono-light,hicolor,gnome-colors-wise
 Comment=Icon theme built for Linux Mint. Uses elements of Faenza and Elementary.
-Directories=actions/16,animations/16,apps/16,categories/16,devices/16,emblems/16,mimetypes/16,places/16,status/16,stock/16,actions/22,animations/22,apps/22,categories/22,devices/22,emblems/22,mimetypes/22,places/22,status/22,stock/22,actions/24,animations/24,apps/24,categories/24,devices/24,emblems/24,mimetypes/24,places/24,status/24,stock/24,actions/32,apps/32,categories/32,devices/32,emblems/32,mimetypes/32,places/32,status/32,stock/32,actions/48,apps/48,categories/48,devices/48,emblems/48,mimetypes/48,places/48,status/48,stock/48,actions/96,apps/96,categories/96,emblems/96,mimetypes/96,status/96,devices/128,places/128,actions/scalable,apps/scalable,devices/scalable,mimetypes/scalable,status/scalable,stock/scalable,places/scalable
+Directories=actions/16,animations/16,apps/16,categories/16,devices/16,emblems/16,mimetypes/16,panel/16,places/16,status/16,stock/16,actions/22,animations/22,apps/22,categories/22,devices/22,emblems/22,mimetypes/22,panel/22,places/22,status/22,stock/22,actions/24,animations/24,apps/24,categories/24,devices/24,emblems/24,mimetypes/24,panel/24,places/24,status/24,stock/24,actions/32,apps/32,categories/32,devices/32,emblems/32,mimetypes/32,panel/32,places/32,status/32,stock/32,actions/48,apps/48,categories/48,devices/48,emblems/48,mimetypes/48,panel/48,places/48,status/48,stock/48,actions/96,apps/96,categories/96,emblems/96,mimetypes/96,status/96,devices/128,places/128,actions/scalable,apps/scalable,devices/scalable,mimetypes/scalable,status/scalable,stock/scalable,places/scalable
 
 Example=directory-x-normal
 
@@ -39,6 +39,11 @@ Type=Fixed
 [mimetypes/16]
 Size=16
 Context=Mimetypes
+Type=Fixed
+
+[panel/16]
+Size=16
+Context=Status
 Type=Fixed
 
 [places/16]
@@ -91,6 +96,11 @@ Size=22
 Context=Mimetypes
 Type=Fixed
 
+[panel/22]
+Size=22
+Context=Status
+Type=Fixed
+
 [places/22]
 Size=22
 Context=Places
@@ -141,6 +151,11 @@ Size=24
 Context=Mimetypes
 Type=Fixed
 
+[panel/24]
+Size=24
+Context=Status
+Type=Fixed
+
 [places/24]
 Size=24
 Context=Places
@@ -184,6 +199,11 @@ Type=Fixed
 [mimetypes/32]
 Size=32
 Context=Mimetypes
+Type=Fixed
+
+[panel/32]
+Size=32
+Context=Status
 Type=Fixed
 
 [places/32]
@@ -230,6 +250,13 @@ Type=Fixed
 Size=48
 Context=Mimetypes
 Type=Fixed
+
+[panel/48]
+Size=48
+MinSize=25
+MaxSize=64
+Context=Status
+Type=Scalable
 
 [places/48]
 Size=48

--- a/usr/share/icons/Mint-X/index.theme
+++ b/usr/share/icons/Mint-X/index.theme
@@ -2,7 +2,7 @@
 Name=Mint-X
 Inherits=gnome,ubuntu-mono-light,hicolor,gnome-colors-wise
 Comment=Icon theme built for Linux Mint. Uses elements of Faenza and Elementary.
-Directories=actions/16,animations/16,apps/16,categories/16,devices/16,emblems/16,mimetypes/16,panel/16,places/16,status/16,stock/16,actions/22,animations/22,apps/22,categories/22,devices/22,emblems/22,mimetypes/22,panel/22,places/22,status/22,stock/22,actions/24,animations/24,apps/24,categories/24,devices/24,emblems/24,mimetypes/24,panel/24,places/24,status/24,stock/24,actions/32,apps/32,categories/32,devices/32,emblems/32,mimetypes/32,panel/32,places/32,status/32,stock/32,actions/48,apps/48,categories/48,devices/48,emblems/48,mimetypes/48,panel/48,places/48,status/48,stock/48,actions/96,apps/96,categories/96,emblems/96,mimetypes/96,panel/96,status/96,devices/128,places/128,actions/scalable,apps/scalable,devices/scalable,mimetypes/scalable,status/scalable,stock/scalable,places/scalable
+Directories=actions/16,animations/16,apps/16,categories/16,devices/16,emblems/16,mimetypes/16,places/16,status/16,stock/16,actions/22,animations/22,apps/22,categories/22,devices/22,emblems/22,mimetypes/22,places/22,status/22,stock/22,actions/24,animations/24,apps/24,categories/24,devices/24,emblems/24,mimetypes/24,places/24,status/24,stock/24,actions/32,apps/32,categories/32,devices/32,emblems/32,mimetypes/32,places/32,status/32,stock/32,actions/48,apps/48,categories/48,devices/48,emblems/48,mimetypes/48,places/48,status/48,stock/48,actions/96,apps/96,categories/96,emblems/96,mimetypes/96,status/96,devices/128,places/128,actions/scalable,apps/scalable,devices/scalable,mimetypes/scalable,status/scalable,stock/scalable,places/scalable
 
 Example=directory-x-normal
 
@@ -39,11 +39,6 @@ Type=Fixed
 [mimetypes/16]
 Size=16
 Context=Mimetypes
-Type=Fixed
-
-[panel/16]
-Size=16
-Context=Status
 Type=Fixed
 
 [places/16]
@@ -96,11 +91,6 @@ Size=22
 Context=Mimetypes
 Type=Fixed
 
-[panel/22]
-Size=22
-Context=Status
-Type=Fixed
-
 [places/22]
 Size=22
 Context=Places
@@ -151,11 +141,6 @@ Size=24
 Context=Mimetypes
 Type=Fixed
 
-[panel/24]
-Size=24
-Context=Status
-Type=Fixed
-
 [places/24]
 Size=24
 Context=Places
@@ -201,11 +186,6 @@ Size=32
 Context=Mimetypes
 Type=Fixed
 
-[panel/32]
-Size=32
-Context=Status
-Type=Fixed
-
 [places/32]
 Size=32
 Context=Places
@@ -249,11 +229,6 @@ Type=Fixed
 [mimetypes/48]
 Size=48
 Context=Mimetypes
-Type=Fixed
-
-[panel/48]
-Size=48
-Context=Status
 Type=Fixed
 
 [places/48]
@@ -305,13 +280,6 @@ Context=Categories
 Type=Scalable
 MinSize=56
 MaxSize=512
-
-[panel/96]
-Size=96
-MinSize=56
-MaxSize=128
-Context=Status
-Type=Scalable
 
 [devices/128]
 Size=128

--- a/usr/share/icons/Mint-X/index.theme
+++ b/usr/share/icons/Mint-X/index.theme
@@ -2,7 +2,7 @@
 Name=Mint-X
 Inherits=gnome,ubuntu-mono-light,hicolor,gnome-colors-wise
 Comment=Icon theme built for Linux Mint. Uses elements of Faenza and Elementary.
-Directories=actions/16,animations/16,apps/16,categories/16,devices/16,emblems/16,mimetypes/16,panel/16,places/16,status/16,stock/16,actions/22,animations/22,apps/22,categories/22,devices/22,emblems/22,mimetypes/22,panel/22,places/22,status/22,stock/22,actions/24,animations/24,apps/24,categories/24,devices/24,emblems/24,mimetypes/24,panel/24,places/24,status/24,stock/24,actions/32,apps/32,categories/32,devices/32,emblems/32,mimetypes/32,panel/32,places/32,status/32,stock/32,actions/48,apps/48,categories/48,devices/48,emblems/48,mimetypes/48,panel/48,places/48,status/48,stock/48,actions/96,apps/96,categories/96,emblems/96,mimetypes/96,status/96,devices/128,places/128,actions/scalable,apps/scalable,devices/scalable,mimetypes/scalable,status/scalable,stock/scalable,places/scalable
+Directories=actions/16,animations/16,apps/16,categories/16,devices/16,emblems/16,mimetypes/16,panel/16,places/16,status/16,stock/16,actions/22,animations/22,apps/22,categories/22,devices/22,emblems/22,mimetypes/22,panel/22,places/22,status/22,stock/22,actions/24,animations/24,apps/24,categories/24,devices/24,emblems/24,mimetypes/24,panel/24,places/24,status/24,stock/24,actions/32,apps/32,categories/32,devices/32,emblems/32,mimetypes/32,panel/32,places/32,status/32,stock/32,actions/48,apps/48,categories/48,devices/48,emblems/48,mimetypes/48,panel/48,places/48,status/48,stock/48,actions/96,apps/96,categories/96,emblems/96,mimetypes/96,panel/96,status/96,devices/128,places/128,actions/scalable,apps/scalable,devices/scalable,mimetypes/scalable,status/scalable,stock/scalable,places/scalable
 
 Example=directory-x-normal
 
@@ -253,10 +253,8 @@ Type=Fixed
 
 [panel/48]
 Size=48
-MinSize=25
-MaxSize=64
 Context=Status
-Type=Scalable
+Type=Fixed
 
 [places/48]
 Size=48
@@ -307,6 +305,13 @@ Context=Categories
 Type=Scalable
 MinSize=56
 MaxSize=512
+
+[panel/96]
+Size=96
+MinSize=56
+MaxSize=128
+Context=Status
+Type=Scalable
 
 [devices/128]
 Size=128

--- a/usr/share/icons/Mint-X/status/22/xfpm-ups-000-charging.png
+++ b/usr/share/icons/Mint-X/status/22/xfpm-ups-000-charging.png
@@ -1,0 +1,1 @@
+gpm-battery-000-charging.png

--- a/usr/share/icons/Mint-X/status/22/xfpm-ups-000.png
+++ b/usr/share/icons/Mint-X/status/22/xfpm-ups-000.png
@@ -1,0 +1,1 @@
+gpm-battery-000.png

--- a/usr/share/icons/Mint-X/status/22/xfpm-ups-020-charging.png
+++ b/usr/share/icons/Mint-X/status/22/xfpm-ups-020-charging.png
@@ -1,0 +1,1 @@
+gpm-battery-020-charging.png

--- a/usr/share/icons/Mint-X/status/22/xfpm-ups-020.png
+++ b/usr/share/icons/Mint-X/status/22/xfpm-ups-020.png
@@ -1,0 +1,1 @@
+gpm-battery-020.png

--- a/usr/share/icons/Mint-X/status/22/xfpm-ups-040-charging.png
+++ b/usr/share/icons/Mint-X/status/22/xfpm-ups-040-charging.png
@@ -1,0 +1,1 @@
+gpm-battery-040-charging.png

--- a/usr/share/icons/Mint-X/status/22/xfpm-ups-040.png
+++ b/usr/share/icons/Mint-X/status/22/xfpm-ups-040.png
@@ -1,0 +1,1 @@
+gpm-battery-040.png

--- a/usr/share/icons/Mint-X/status/22/xfpm-ups-060-charging.png
+++ b/usr/share/icons/Mint-X/status/22/xfpm-ups-060-charging.png
@@ -1,0 +1,1 @@
+gpm-battery-060-charging.png

--- a/usr/share/icons/Mint-X/status/22/xfpm-ups-060.png
+++ b/usr/share/icons/Mint-X/status/22/xfpm-ups-060.png
@@ -1,0 +1,1 @@
+gpm-battery-060.png

--- a/usr/share/icons/Mint-X/status/22/xfpm-ups-080-charging.png
+++ b/usr/share/icons/Mint-X/status/22/xfpm-ups-080-charging.png
@@ -1,0 +1,1 @@
+gpm-battery-080-charging.png

--- a/usr/share/icons/Mint-X/status/22/xfpm-ups-080.png
+++ b/usr/share/icons/Mint-X/status/22/xfpm-ups-080.png
@@ -1,0 +1,1 @@
+gpm-battery-080.png

--- a/usr/share/icons/Mint-X/status/22/xfpm-ups-100-charging.png
+++ b/usr/share/icons/Mint-X/status/22/xfpm-ups-100-charging.png
@@ -1,0 +1,1 @@
+gpm-battery-100-charging.png

--- a/usr/share/icons/Mint-X/status/22/xfpm-ups-100.png
+++ b/usr/share/icons/Mint-X/status/22/xfpm-ups-100.png
@@ -1,0 +1,1 @@
+gpm-battery-100.png

--- a/usr/share/icons/Mint-X/status/22/xfpm-ups-charged.png
+++ b/usr/share/icons/Mint-X/status/22/xfpm-ups-charged.png
@@ -1,0 +1,1 @@
+gpm-battery-charged.png

--- a/usr/share/icons/Mint-X/status/22/xfpm-ups-missing.png
+++ b/usr/share/icons/Mint-X/status/22/xfpm-ups-missing.png
@@ -1,0 +1,1 @@
+gpm-battery-000.png

--- a/usr/share/icons/Mint-X/status/24/xfpm-ups-000-charging.png
+++ b/usr/share/icons/Mint-X/status/24/xfpm-ups-000-charging.png
@@ -1,0 +1,1 @@
+gpm-battery-000-charging.png

--- a/usr/share/icons/Mint-X/status/24/xfpm-ups-000.png
+++ b/usr/share/icons/Mint-X/status/24/xfpm-ups-000.png
@@ -1,0 +1,1 @@
+gpm-battery-000.png

--- a/usr/share/icons/Mint-X/status/24/xfpm-ups-020-charging.png
+++ b/usr/share/icons/Mint-X/status/24/xfpm-ups-020-charging.png
@@ -1,0 +1,1 @@
+gpm-battery-020-charging.png

--- a/usr/share/icons/Mint-X/status/24/xfpm-ups-020.png
+++ b/usr/share/icons/Mint-X/status/24/xfpm-ups-020.png
@@ -1,0 +1,1 @@
+gpm-battery-020.png

--- a/usr/share/icons/Mint-X/status/24/xfpm-ups-040-charging.png
+++ b/usr/share/icons/Mint-X/status/24/xfpm-ups-040-charging.png
@@ -1,0 +1,1 @@
+gpm-battery-040-charging.png

--- a/usr/share/icons/Mint-X/status/24/xfpm-ups-040.png
+++ b/usr/share/icons/Mint-X/status/24/xfpm-ups-040.png
@@ -1,0 +1,1 @@
+gpm-battery-040.png

--- a/usr/share/icons/Mint-X/status/24/xfpm-ups-060-charging.png
+++ b/usr/share/icons/Mint-X/status/24/xfpm-ups-060-charging.png
@@ -1,0 +1,1 @@
+gpm-battery-060-charging.png

--- a/usr/share/icons/Mint-X/status/24/xfpm-ups-060.png
+++ b/usr/share/icons/Mint-X/status/24/xfpm-ups-060.png
@@ -1,0 +1,1 @@
+gpm-battery-060.png

--- a/usr/share/icons/Mint-X/status/24/xfpm-ups-080-charging.png
+++ b/usr/share/icons/Mint-X/status/24/xfpm-ups-080-charging.png
@@ -1,0 +1,1 @@
+gpm-battery-080-charging.png

--- a/usr/share/icons/Mint-X/status/24/xfpm-ups-080.png
+++ b/usr/share/icons/Mint-X/status/24/xfpm-ups-080.png
@@ -1,0 +1,1 @@
+gpm-battery-080.png

--- a/usr/share/icons/Mint-X/status/24/xfpm-ups-100-charging.png
+++ b/usr/share/icons/Mint-X/status/24/xfpm-ups-100-charging.png
@@ -1,0 +1,1 @@
+gpm-battery-100-charging.png

--- a/usr/share/icons/Mint-X/status/24/xfpm-ups-100.png
+++ b/usr/share/icons/Mint-X/status/24/xfpm-ups-100.png
@@ -1,0 +1,1 @@
+gpm-battery-100.png

--- a/usr/share/icons/Mint-X/status/24/xfpm-ups-charged.png
+++ b/usr/share/icons/Mint-X/status/24/xfpm-ups-charged.png
@@ -1,0 +1,1 @@
+gpm-battery-charged.png

--- a/usr/share/icons/Mint-X/status/24/xfpm-ups-missing.png
+++ b/usr/share/icons/Mint-X/status/24/xfpm-ups-missing.png
@@ -1,0 +1,1 @@
+gpm-battery-000.png

--- a/usr/share/icons/Mint-X/status/32/xfpm-ups-000-charging.png
+++ b/usr/share/icons/Mint-X/status/32/xfpm-ups-000-charging.png
@@ -1,0 +1,1 @@
+gpm-battery-000-charging.png

--- a/usr/share/icons/Mint-X/status/32/xfpm-ups-000.png
+++ b/usr/share/icons/Mint-X/status/32/xfpm-ups-000.png
@@ -1,0 +1,1 @@
+gpm-battery-000.png

--- a/usr/share/icons/Mint-X/status/32/xfpm-ups-020-charging.png
+++ b/usr/share/icons/Mint-X/status/32/xfpm-ups-020-charging.png
@@ -1,0 +1,1 @@
+gpm-battery-020-charging.png

--- a/usr/share/icons/Mint-X/status/32/xfpm-ups-020.png
+++ b/usr/share/icons/Mint-X/status/32/xfpm-ups-020.png
@@ -1,0 +1,1 @@
+gpm-battery-020.png

--- a/usr/share/icons/Mint-X/status/32/xfpm-ups-040-charging.png
+++ b/usr/share/icons/Mint-X/status/32/xfpm-ups-040-charging.png
@@ -1,0 +1,1 @@
+gpm-battery-040-charging.png

--- a/usr/share/icons/Mint-X/status/32/xfpm-ups-040.png
+++ b/usr/share/icons/Mint-X/status/32/xfpm-ups-040.png
@@ -1,0 +1,1 @@
+gpm-battery-040.png

--- a/usr/share/icons/Mint-X/status/32/xfpm-ups-060-charging.png
+++ b/usr/share/icons/Mint-X/status/32/xfpm-ups-060-charging.png
@@ -1,0 +1,1 @@
+gpm-battery-060-charging.png

--- a/usr/share/icons/Mint-X/status/32/xfpm-ups-060.png
+++ b/usr/share/icons/Mint-X/status/32/xfpm-ups-060.png
@@ -1,0 +1,1 @@
+gpm-battery-060.png

--- a/usr/share/icons/Mint-X/status/32/xfpm-ups-080-charging.png
+++ b/usr/share/icons/Mint-X/status/32/xfpm-ups-080-charging.png
@@ -1,0 +1,1 @@
+gpm-battery-080-charging.png

--- a/usr/share/icons/Mint-X/status/32/xfpm-ups-080.png
+++ b/usr/share/icons/Mint-X/status/32/xfpm-ups-080.png
@@ -1,0 +1,1 @@
+gpm-battery-080.png

--- a/usr/share/icons/Mint-X/status/32/xfpm-ups-100-charging.png
+++ b/usr/share/icons/Mint-X/status/32/xfpm-ups-100-charging.png
@@ -1,0 +1,1 @@
+gpm-battery-100-charging.png

--- a/usr/share/icons/Mint-X/status/32/xfpm-ups-100.png
+++ b/usr/share/icons/Mint-X/status/32/xfpm-ups-100.png
@@ -1,0 +1,1 @@
+gpm-battery-100.png

--- a/usr/share/icons/Mint-X/status/32/xfpm-ups-charged.png
+++ b/usr/share/icons/Mint-X/status/32/xfpm-ups-charged.png
@@ -1,0 +1,1 @@
+gpm-battery-charged.png

--- a/usr/share/icons/Mint-X/status/32/xfpm-ups-missing.png
+++ b/usr/share/icons/Mint-X/status/32/xfpm-ups-missing.png
@@ -1,0 +1,1 @@
+gpm-battery-000.png

--- a/usr/share/icons/Mint-X/status/48/xfpm-ups-000-charging.png
+++ b/usr/share/icons/Mint-X/status/48/xfpm-ups-000-charging.png
@@ -1,0 +1,1 @@
+gpm-battery-000-charging.png

--- a/usr/share/icons/Mint-X/status/48/xfpm-ups-000.png
+++ b/usr/share/icons/Mint-X/status/48/xfpm-ups-000.png
@@ -1,0 +1,1 @@
+gpm-battery-000.png

--- a/usr/share/icons/Mint-X/status/48/xfpm-ups-020-charging.png
+++ b/usr/share/icons/Mint-X/status/48/xfpm-ups-020-charging.png
@@ -1,0 +1,1 @@
+gpm-battery-020-charging.png

--- a/usr/share/icons/Mint-X/status/48/xfpm-ups-020.png
+++ b/usr/share/icons/Mint-X/status/48/xfpm-ups-020.png
@@ -1,0 +1,1 @@
+gpm-battery-020.png

--- a/usr/share/icons/Mint-X/status/48/xfpm-ups-040-charging.png
+++ b/usr/share/icons/Mint-X/status/48/xfpm-ups-040-charging.png
@@ -1,0 +1,1 @@
+gpm-battery-040-charging.png

--- a/usr/share/icons/Mint-X/status/48/xfpm-ups-040.png
+++ b/usr/share/icons/Mint-X/status/48/xfpm-ups-040.png
@@ -1,0 +1,1 @@
+gpm-battery-040.png

--- a/usr/share/icons/Mint-X/status/48/xfpm-ups-060-charging.png
+++ b/usr/share/icons/Mint-X/status/48/xfpm-ups-060-charging.png
@@ -1,0 +1,1 @@
+gpm-battery-060-charging.png

--- a/usr/share/icons/Mint-X/status/48/xfpm-ups-060.png
+++ b/usr/share/icons/Mint-X/status/48/xfpm-ups-060.png
@@ -1,0 +1,1 @@
+gpm-battery-060.png

--- a/usr/share/icons/Mint-X/status/48/xfpm-ups-080-charging.png
+++ b/usr/share/icons/Mint-X/status/48/xfpm-ups-080-charging.png
@@ -1,0 +1,1 @@
+gpm-battery-080-charging.png

--- a/usr/share/icons/Mint-X/status/48/xfpm-ups-080.png
+++ b/usr/share/icons/Mint-X/status/48/xfpm-ups-080.png
@@ -1,0 +1,1 @@
+gpm-battery-080.png

--- a/usr/share/icons/Mint-X/status/48/xfpm-ups-100-charging.png
+++ b/usr/share/icons/Mint-X/status/48/xfpm-ups-100-charging.png
@@ -1,0 +1,1 @@
+gpm-battery-100-charging.png

--- a/usr/share/icons/Mint-X/status/48/xfpm-ups-100.png
+++ b/usr/share/icons/Mint-X/status/48/xfpm-ups-100.png
@@ -1,0 +1,1 @@
+gpm-battery-100.png

--- a/usr/share/icons/Mint-X/status/48/xfpm-ups-charged.png
+++ b/usr/share/icons/Mint-X/status/48/xfpm-ups-charged.png
@@ -1,0 +1,1 @@
+gpm-battery-charged.png

--- a/usr/share/icons/Mint-X/status/48/xfpm-ups-missing.png
+++ b/usr/share/icons/Mint-X/status/48/xfpm-ups-missing.png
@@ -1,0 +1,1 @@
+gpm-battery-000.png

--- a/usr/share/icons/Mint-X/status/96/xfpm-ups-000-charging.svg
+++ b/usr/share/icons/Mint-X/status/96/xfpm-ups-000-charging.svg
@@ -1,0 +1,1 @@
+gpm-battery-000-charging.svg

--- a/usr/share/icons/Mint-X/status/96/xfpm-ups-000.svg
+++ b/usr/share/icons/Mint-X/status/96/xfpm-ups-000.svg
@@ -1,0 +1,1 @@
+gpm-battery-000.svg

--- a/usr/share/icons/Mint-X/status/96/xfpm-ups-020-charging.svg
+++ b/usr/share/icons/Mint-X/status/96/xfpm-ups-020-charging.svg
@@ -1,0 +1,1 @@
+gpm-battery-020-charging.svg

--- a/usr/share/icons/Mint-X/status/96/xfpm-ups-020.svg
+++ b/usr/share/icons/Mint-X/status/96/xfpm-ups-020.svg
@@ -1,0 +1,1 @@
+gpm-battery-020.svg

--- a/usr/share/icons/Mint-X/status/96/xfpm-ups-040-charging.svg
+++ b/usr/share/icons/Mint-X/status/96/xfpm-ups-040-charging.svg
@@ -1,0 +1,1 @@
+gpm-battery-040-charging.svg

--- a/usr/share/icons/Mint-X/status/96/xfpm-ups-040.svg
+++ b/usr/share/icons/Mint-X/status/96/xfpm-ups-040.svg
@@ -1,0 +1,1 @@
+gpm-battery-040.svg

--- a/usr/share/icons/Mint-X/status/96/xfpm-ups-060-charging.svg
+++ b/usr/share/icons/Mint-X/status/96/xfpm-ups-060-charging.svg
@@ -1,0 +1,1 @@
+gpm-battery-060-charging.svg

--- a/usr/share/icons/Mint-X/status/96/xfpm-ups-060.svg
+++ b/usr/share/icons/Mint-X/status/96/xfpm-ups-060.svg
@@ -1,0 +1,1 @@
+gpm-battery-060.svg

--- a/usr/share/icons/Mint-X/status/96/xfpm-ups-080-charging.svg
+++ b/usr/share/icons/Mint-X/status/96/xfpm-ups-080-charging.svg
@@ -1,0 +1,1 @@
+gpm-battery-080-charging.svg

--- a/usr/share/icons/Mint-X/status/96/xfpm-ups-080.svg
+++ b/usr/share/icons/Mint-X/status/96/xfpm-ups-080.svg
@@ -1,0 +1,1 @@
+gpm-battery-080.svg

--- a/usr/share/icons/Mint-X/status/96/xfpm-ups-100-charging.svg
+++ b/usr/share/icons/Mint-X/status/96/xfpm-ups-100-charging.svg
@@ -1,0 +1,1 @@
+gpm-battery-100-charging.svg

--- a/usr/share/icons/Mint-X/status/96/xfpm-ups-100.svg
+++ b/usr/share/icons/Mint-X/status/96/xfpm-ups-100.svg
@@ -1,0 +1,1 @@
+gpm-battery-100.svg

--- a/usr/share/icons/Mint-X/status/96/xfpm-ups-charged.svg
+++ b/usr/share/icons/Mint-X/status/96/xfpm-ups-charged.svg
@@ -1,0 +1,1 @@
+gpm-battery-charged.svg

--- a/usr/share/icons/Mint-X/status/96/xfpm-ups-missing.svg
+++ b/usr/share/icons/Mint-X/status/96/xfpm-ups-missing.svg
@@ -1,0 +1,1 @@
+gpm-battery-000.svg


### PR DESCRIPTION
#120 I've found the reason of this bug, my APC UPS is recognized as UPS, not battery, so I wasn't able to see icon. This commit fixes it