### PR TITLE
UPS icons support for xfce power manager

### DIFF
--- a/usr/share/icons/Mint-X/status/22/xfpm-ups-000-charging.png
+++ b/usr/share/icons/Mint-X/status/22/xfpm-ups-000-charging.png
@@ -1,0 +1,1 @@
+gpm-battery-000-charging.png

--- a/usr/share/icons/Mint-X/status/22/xfpm-ups-000.png
+++ b/usr/share/icons/Mint-X/status/22/xfpm-ups-000.png
@@ -1,0 +1,1 @@
+gpm-battery-000.png

--- a/usr/share/icons/Mint-X/status/22/xfpm-ups-020-charging.png
+++ b/usr/share/icons/Mint-X/status/22/xfpm-ups-020-charging.png
@@ -1,0 +1,1 @@
+gpm-battery-020-charging.png

--- a/usr/share/icons/Mint-X/status/22/xfpm-ups-020.png
+++ b/usr/share/icons/Mint-X/status/22/xfpm-ups-020.png
@@ -1,0 +1,1 @@
+gpm-battery-020.png

--- a/usr/share/icons/Mint-X/status/22/xfpm-ups-040-charging.png
+++ b/usr/share/icons/Mint-X/status/22/xfpm-ups-040-charging.png
@@ -1,0 +1,1 @@
+gpm-battery-040-charging.png

--- a/usr/share/icons/Mint-X/status/22/xfpm-ups-040.png
+++ b/usr/share/icons/Mint-X/status/22/xfpm-ups-040.png
@@ -1,0 +1,1 @@
+gpm-battery-040.png

--- a/usr/share/icons/Mint-X/status/22/xfpm-ups-060-charging.png
+++ b/usr/share/icons/Mint-X/status/22/xfpm-ups-060-charging.png
@@ -1,0 +1,1 @@
+gpm-battery-060-charging.png

--- a/usr/share/icons/Mint-X/status/22/xfpm-ups-060.png
+++ b/usr/share/icons/Mint-X/status/22/xfpm-ups-060.png
@@ -1,0 +1,1 @@
+gpm-battery-060.png

--- a/usr/share/icons/Mint-X/status/22/xfpm-ups-080-charging.png
+++ b/usr/share/icons/Mint-X/status/22/xfpm-ups-080-charging.png
@@ -1,0 +1,1 @@
+gpm-battery-080-charging.png

--- a/usr/share/icons/Mint-X/status/22/xfpm-ups-080.png
+++ b/usr/share/icons/Mint-X/status/22/xfpm-ups-080.png
@@ -1,0 +1,1 @@
+gpm-battery-080.png

--- a/usr/share/icons/Mint-X/status/22/xfpm-ups-100-charging.png
+++ b/usr/share/icons/Mint-X/status/22/xfpm-ups-100-charging.png
@@ -1,0 +1,1 @@
+gpm-battery-100-charging.png

--- a/usr/share/icons/Mint-X/status/22/xfpm-ups-100.png
+++ b/usr/share/icons/Mint-X/status/22/xfpm-ups-100.png
@@ -1,0 +1,1 @@
+gpm-battery-100.png

--- a/usr/share/icons/Mint-X/status/22/xfpm-ups-charged.png
+++ b/usr/share/icons/Mint-X/status/22/xfpm-ups-charged.png
@@ -1,0 +1,1 @@
+gpm-battery-charged.png

--- a/usr/share/icons/Mint-X/status/22/xfpm-ups-missing.png
+++ b/usr/share/icons/Mint-X/status/22/xfpm-ups-missing.png
@@ -1,0 +1,1 @@
+gpm-battery-000.png

--- a/usr/share/icons/Mint-X/status/24/xfpm-ups-000-charging.png
+++ b/usr/share/icons/Mint-X/status/24/xfpm-ups-000-charging.png
@@ -1,0 +1,1 @@
+gpm-battery-000-charging.png

--- a/usr/share/icons/Mint-X/status/24/xfpm-ups-000.png
+++ b/usr/share/icons/Mint-X/status/24/xfpm-ups-000.png
@@ -1,0 +1,1 @@
+gpm-battery-000.png

--- a/usr/share/icons/Mint-X/status/24/xfpm-ups-020-charging.png
+++ b/usr/share/icons/Mint-X/status/24/xfpm-ups-020-charging.png
@@ -1,0 +1,1 @@
+gpm-battery-020-charging.png

--- a/usr/share/icons/Mint-X/status/24/xfpm-ups-020.png
+++ b/usr/share/icons/Mint-X/status/24/xfpm-ups-020.png
@@ -1,0 +1,1 @@
+gpm-battery-020.png

--- a/usr/share/icons/Mint-X/status/24/xfpm-ups-040-charging.png
+++ b/usr/share/icons/Mint-X/status/24/xfpm-ups-040-charging.png
@@ -1,0 +1,1 @@
+gpm-battery-040-charging.png

--- a/usr/share/icons/Mint-X/status/24/xfpm-ups-040.png
+++ b/usr/share/icons/Mint-X/status/24/xfpm-ups-040.png
@@ -1,0 +1,1 @@
+gpm-battery-040.png

--- a/usr/share/icons/Mint-X/status/24/xfpm-ups-060-charging.png
+++ b/usr/share/icons/Mint-X/status/24/xfpm-ups-060-charging.png
@@ -1,0 +1,1 @@
+gpm-battery-060-charging.png

--- a/usr/share/icons/Mint-X/status/24/xfpm-ups-060.png
+++ b/usr/share/icons/Mint-X/status/24/xfpm-ups-060.png
@@ -1,0 +1,1 @@
+gpm-battery-060.png

--- a/usr/share/icons/Mint-X/status/24/xfpm-ups-080-charging.png
+++ b/usr/share/icons/Mint-X/status/24/xfpm-ups-080-charging.png
@@ -1,0 +1,1 @@
+gpm-battery-080-charging.png

--- a/usr/share/icons/Mint-X/status/24/xfpm-ups-080.png
+++ b/usr/share/icons/Mint-X/status/24/xfpm-ups-080.png
@@ -1,0 +1,1 @@
+gpm-battery-080.png

--- a/usr/share/icons/Mint-X/status/24/xfpm-ups-100-charging.png
+++ b/usr/share/icons/Mint-X/status/24/xfpm-ups-100-charging.png
@@ -1,0 +1,1 @@
+gpm-battery-100-charging.png

--- a/usr/share/icons/Mint-X/status/24/xfpm-ups-100.png
+++ b/usr/share/icons/Mint-X/status/24/xfpm-ups-100.png
@@ -1,0 +1,1 @@
+gpm-battery-100.png

--- a/usr/share/icons/Mint-X/status/24/xfpm-ups-charged.png
+++ b/usr/share/icons/Mint-X/status/24/xfpm-ups-charged.png
@@ -1,0 +1,1 @@
+gpm-battery-charged.png

--- a/usr/share/icons/Mint-X/status/24/xfpm-ups-missing.png
+++ b/usr/share/icons/Mint-X/status/24/xfpm-ups-missing.png
@@ -1,0 +1,1 @@
+gpm-battery-000.png

--- a/usr/share/icons/Mint-X/status/32/xfpm-ups-000-charging.png
+++ b/usr/share/icons/Mint-X/status/32/xfpm-ups-000-charging.png
@@ -1,0 +1,1 @@
+gpm-battery-000-charging.png

--- a/usr/share/icons/Mint-X/status/32/xfpm-ups-000.png
+++ b/usr/share/icons/Mint-X/status/32/xfpm-ups-000.png
@@ -1,0 +1,1 @@
+gpm-battery-000.png

--- a/usr/share/icons/Mint-X/status/32/xfpm-ups-020-charging.png
+++ b/usr/share/icons/Mint-X/status/32/xfpm-ups-020-charging.png
@@ -1,0 +1,1 @@
+gpm-battery-020-charging.png

--- a/usr/share/icons/Mint-X/status/32/xfpm-ups-020.png
+++ b/usr/share/icons/Mint-X/status/32/xfpm-ups-020.png
@@ -1,0 +1,1 @@
+gpm-battery-020.png

--- a/usr/share/icons/Mint-X/status/32/xfpm-ups-040-charging.png
+++ b/usr/share/icons/Mint-X/status/32/xfpm-ups-040-charging.png
@@ -1,0 +1,1 @@
+gpm-battery-040-charging.png

--- a/usr/share/icons/Mint-X/status/32/xfpm-ups-040.png
+++ b/usr/share/icons/Mint-X/status/32/xfpm-ups-040.png
@@ -1,0 +1,1 @@
+gpm-battery-040.png

--- a/usr/share/icons/Mint-X/status/32/xfpm-ups-060-charging.png
+++ b/usr/share/icons/Mint-X/status/32/xfpm-ups-060-charging.png
@@ -1,0 +1,1 @@
+gpm-battery-060-charging.png

--- a/usr/share/icons/Mint-X/status/32/xfpm-ups-060.png
+++ b/usr/share/icons/Mint-X/status/32/xfpm-ups-060.png
@@ -1,0 +1,1 @@
+gpm-battery-060.png

--- a/usr/share/icons/Mint-X/status/32/xfpm-ups-080-charging.png
+++ b/usr/share/icons/Mint-X/status/32/xfpm-ups-080-charging.png
@@ -1,0 +1,1 @@
+gpm-battery-080-charging.png

--- a/usr/share/icons/Mint-X/status/32/xfpm-ups-080.png
+++ b/usr/share/icons/Mint-X/status/32/xfpm-ups-080.png
@@ -1,0 +1,1 @@
+gpm-battery-080.png

--- a/usr/share/icons/Mint-X/status/32/xfpm-ups-100-charging.png
+++ b/usr/share/icons/Mint-X/status/32/xfpm-ups-100-charging.png
@@ -1,0 +1,1 @@
+gpm-battery-100-charging.png

--- a/usr/share/icons/Mint-X/status/32/xfpm-ups-100.png
+++ b/usr/share/icons/Mint-X/status/32/xfpm-ups-100.png
@@ -1,0 +1,1 @@
+gpm-battery-100.png

--- a/usr/share/icons/Mint-X/status/32/xfpm-ups-charged.png
+++ b/usr/share/icons/Mint-X/status/32/xfpm-ups-charged.png
@@ -1,0 +1,1 @@
+gpm-battery-charged.png

--- a/usr/share/icons/Mint-X/status/32/xfpm-ups-missing.png
+++ b/usr/share/icons/Mint-X/status/32/xfpm-ups-missing.png
@@ -1,0 +1,1 @@
+gpm-battery-000.png

--- a/usr/share/icons/Mint-X/status/48/xfpm-ups-000-charging.png
+++ b/usr/share/icons/Mint-X/status/48/xfpm-ups-000-charging.png
@@ -1,0 +1,1 @@
+gpm-battery-000-charging.png

--- a/usr/share/icons/Mint-X/status/48/xfpm-ups-000.png
+++ b/usr/share/icons/Mint-X/status/48/xfpm-ups-000.png
@@ -1,0 +1,1 @@
+gpm-battery-000.png

--- a/usr/share/icons/Mint-X/status/48/xfpm-ups-020-charging.png
+++ b/usr/share/icons/Mint-X/status/48/xfpm-ups-020-charging.png
@@ -1,0 +1,1 @@
+gpm-battery-020-charging.png

--- a/usr/share/icons/Mint-X/status/48/xfpm-ups-020.png
+++ b/usr/share/icons/Mint-X/status/48/xfpm-ups-020.png
@@ -1,0 +1,1 @@
+gpm-battery-020.png

--- a/usr/share/icons/Mint-X/status/48/xfpm-ups-040-charging.png
+++ b/usr/share/icons/Mint-X/status/48/xfpm-ups-040-charging.png
@@ -1,0 +1,1 @@
+gpm-battery-040-charging.png

--- a/usr/share/icons/Mint-X/status/48/xfpm-ups-040.png
+++ b/usr/share/icons/Mint-X/status/48/xfpm-ups-040.png
@@ -1,0 +1,1 @@
+gpm-battery-040.png

--- a/usr/share/icons/Mint-X/status/48/xfpm-ups-060-charging.png
+++ b/usr/share/icons/Mint-X/status/48/xfpm-ups-060-charging.png
@@ -1,0 +1,1 @@
+gpm-battery-060-charging.png

--- a/usr/share/icons/Mint-X/status/48/xfpm-ups-060.png
+++ b/usr/share/icons/Mint-X/status/48/xfpm-ups-060.png
@@ -1,0 +1,1 @@
+gpm-battery-060.png

--- a/usr/share/icons/Mint-X/status/48/xfpm-ups-080-charging.png
+++ b/usr/share/icons/Mint-X/status/48/xfpm-ups-080-charging.png
@@ -1,0 +1,1 @@
+gpm-battery-080-charging.png

--- a/usr/share/icons/Mint-X/status/48/xfpm-ups-080.png
+++ b/usr/share/icons/Mint-X/status/48/xfpm-ups-080.png
@@ -1,0 +1,1 @@
+gpm-battery-080.png

--- a/usr/share/icons/Mint-X/status/48/xfpm-ups-100-charging.png
+++ b/usr/share/icons/Mint-X/status/48/xfpm-ups-100-charging.png
@@ -1,0 +1,1 @@
+gpm-battery-100-charging.png

--- a/usr/share/icons/Mint-X/status/48/xfpm-ups-100.png
+++ b/usr/share/icons/Mint-X/status/48/xfpm-ups-100.png
@@ -1,0 +1,1 @@
+gpm-battery-100.png

--- a/usr/share/icons/Mint-X/status/48/xfpm-ups-charged.png
+++ b/usr/share/icons/Mint-X/status/48/xfpm-ups-charged.png
@@ -1,0 +1,1 @@
+gpm-battery-charged.png

--- a/usr/share/icons/Mint-X/status/48/xfpm-ups-missing.png
+++ b/usr/share/icons/Mint-X/status/48/xfpm-ups-missing.png
@@ -1,0 +1,1 @@
+gpm-battery-000.png

--- a/usr/share/icons/Mint-X/status/96/xfpm-ups-000-charging.svg
+++ b/usr/share/icons/Mint-X/status/96/xfpm-ups-000-charging.svg
@@ -1,0 +1,1 @@
+gpm-battery-000-charging.svg

--- a/usr/share/icons/Mint-X/status/96/xfpm-ups-000.svg
+++ b/usr/share/icons/Mint-X/status/96/xfpm-ups-000.svg
@@ -1,0 +1,1 @@
+gpm-battery-000.svg

--- a/usr/share/icons/Mint-X/status/96/xfpm-ups-020-charging.svg
+++ b/usr/share/icons/Mint-X/status/96/xfpm-ups-020-charging.svg
@@ -1,0 +1,1 @@
+gpm-battery-020-charging.svg

--- a/usr/share/icons/Mint-X/status/96/xfpm-ups-020.svg
+++ b/usr/share/icons/Mint-X/status/96/xfpm-ups-020.svg
@@ -1,0 +1,1 @@
+gpm-battery-020.svg

--- a/usr/share/icons/Mint-X/status/96/xfpm-ups-040-charging.svg
+++ b/usr/share/icons/Mint-X/status/96/xfpm-ups-040-charging.svg
@@ -1,0 +1,1 @@
+gpm-battery-040-charging.svg

--- a/usr/share/icons/Mint-X/status/96/xfpm-ups-040.svg
+++ b/usr/share/icons/Mint-X/status/96/xfpm-ups-040.svg
@@ -1,0 +1,1 @@
+gpm-battery-040.svg

--- a/usr/share/icons/Mint-X/status/96/xfpm-ups-060-charging.svg
+++ b/usr/share/icons/Mint-X/status/96/xfpm-ups-060-charging.svg
@@ -1,0 +1,1 @@
+gpm-battery-060-charging.svg

--- a/usr/share/icons/Mint-X/status/96/xfpm-ups-060.svg
+++ b/usr/share/icons/Mint-X/status/96/xfpm-ups-060.svg
@@ -1,0 +1,1 @@
+gpm-battery-060.svg

--- a/usr/share/icons/Mint-X/status/96/xfpm-ups-080-charging.svg
+++ b/usr/share/icons/Mint-X/status/96/xfpm-ups-080-charging.svg
@@ -1,0 +1,1 @@
+gpm-battery-080-charging.svg

--- a/usr/share/icons/Mint-X/status/96/xfpm-ups-080.svg
+++ b/usr/share/icons/Mint-X/status/96/xfpm-ups-080.svg
@@ -1,0 +1,1 @@
+gpm-battery-080.svg

--- a/usr/share/icons/Mint-X/status/96/xfpm-ups-100-charging.svg
+++ b/usr/share/icons/Mint-X/status/96/xfpm-ups-100-charging.svg
@@ -1,0 +1,1 @@
+gpm-battery-100-charging.svg

--- a/usr/share/icons/Mint-X/status/96/xfpm-ups-100.svg
+++ b/usr/share/icons/Mint-X/status/96/xfpm-ups-100.svg
@@ -1,0 +1,1 @@
+gpm-battery-100.svg

--- a/usr/share/icons/Mint-X/status/96/xfpm-ups-charged.svg
+++ b/usr/share/icons/Mint-X/status/96/xfpm-ups-charged.svg
@@ -1,0 +1,1 @@
+gpm-battery-charged.svg

--- a/usr/share/icons/Mint-X/status/96/xfpm-ups-missing.svg
+++ b/usr/share/icons/Mint-X/status/96/xfpm-ups-missing.svg
@@ -1,0 +1,1 @@
+gpm-battery-000.svg


### PR DESCRIPTION
This PR is the same as #123 , it was created again due to reorganising my repository. This fixes #120 