### PR TITLE
Add icon-theme.cache files to the .gitignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+icon-theme.cache


### PR DESCRIPTION
These files can get created in the git repo if you use a development
tree as a system theme.