### PR TITLE
Add some symbolics

### DIFF
--- a/usr/share/icons/Mint-X/actions/scalable/help-about-symbolic.svg
+++ b/usr/share/icons/Mint-X/actions/scalable/help-about-symbolic.svg
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   id="svg4185"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="help-about-symbolic.svg">
+  <defs
+     id="defs4187" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.4"
+     inkscape:cx="7.4784323"
+     inkscape:cy="10.423838"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true"
+     inkscape:bbox-paths="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:snap-global="false"
+     inkscape:window-width="1500"
+     inkscape:window-height="814"
+     inkscape:window-x="270"
+     inkscape:window-y="89"
+     inkscape:window-maximized="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4739" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata4190">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="opacity:1;fill:#bebebe;fill-opacity:1"
+       d="M 8 2 A 6.9999959 5.4999796 0 0 0 1 7.5 A 6.9999959 5.4999796 0 0 0 4.0273438 12.027344 C 4.0956437 12.235444 4.1705956 12.583981 3.9160156 13.050781 C 3.559926 13.703881 3.0332031 14.017578 3.0332031 14.017578 L 3 15 L 4 15 C 4 15 5.4663972 14.4412 5.9667969 14 C 6.3882766 13.6287 6.5040125 13.072053 6.5390625 12.876953 A 6.9999959 5.4999796 0 0 0 8 13 A 6.9999959 5.4999796 0 0 0 15 7.5 A 6.9999959 5.4999796 0 0 0 8 2 z M 7.1738281 2.84375 L 8.7207031 2.84375 L 8.7207031 4.5664062 L 7.1738281 4.5664062 L 7.1738281 2.84375 z M 5.6601562 5.5898438 L 8.7207031 5.5898438 L 8.7207031 10.097656 L 10.640625 10.097656 L 10.640625 11.230469 L 5.2480469 11.230469 L 5.2480469 10.097656 L 7.1738281 10.097656 L 7.1738281 6.7226562 L 5.6601562 6.7226562 L 5.6601562 5.5898438 z "
+       transform="translate(0,1036.3622)"
+       id="path4138" />
+    <g
+       transform="matrix(0.9602398,0,0,0.91702178,0.12296443,1035.9022)"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:11.25px;line-height:125%;font-family:'DejaVu Sans Mono';-inkscape-font-specification:'DejaVu Sans Mono, Bold';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       id="flowRoot4138" />
+  </g>
+</svg>

--- a/usr/share/icons/Mint-X/actions/scalable/zoom-in-symbolic.svg
+++ b/usr/share/icons/Mint-X/actions/scalable/zoom-in-symbolic.svg
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg7384"
+   height="16"
+   width="16"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="zoom-in-symbolic.svg">
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1152"
+     inkscape:window-height="715"
+     id="namedview8"
+     showgrid="true"
+     inkscape:zoom="29.5"
+     inkscape:cx="8.3007651"
+     inkscape:cy="8.0438477"
+     inkscape:window-x="570"
+     inkscape:window-y="160"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg7384"
+     inkscape:snap-global="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4138" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata90">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Gnome Symbolic Icon Theme</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <title
+     id="title9167">Gnome Symbolic Icon Theme</title>
+  <g
+     id="layer11"
+     transform="translate(-41 -667)">
+    <path
+       id="path5254"
+       style="block-progression:tb;text-indent:0;color:#000000;enable-background:new;text-transform:none;fill:#bebebe"
+       d="m47.508 668c-3.0289 0-5.5107 2.479-5.5107 5.5045 0 3.0254 2.4819 5.5045 5.5107 5.5045 3.0289 0 5.5107-2.479 5.5107-5.5045 0-3.0254-2.4819-5.5045-5.5107-5.5045zm0 2.0089c1.9474 0 3.4995 1.5504 3.4995 3.4955s-1.5522 3.4955-3.4995 3.4955c-1.9474 0-3.4995-1.5504-3.4995-3.4955 0-1.9452 1.5522-3.4955 3.4995-3.4955z" />
+    <path
+       id="path5256"
+       style="block-progression:tb;text-indent:0;color:#000000;enable-background:new;text-transform:none;fill:#bebebe"
+       d="m50.812 676a1.0001 1.0001 0 0 0 -0.5 1.7188l4 4a1.0055 1.0055 0 1 0 1.4062 -1.4375l-4-4a1.0001 1.0001 0 0 0 -0.906 -0.28z" />
+  </g>
+  <rect
+     style="opacity:1;fill:#bebebe;fill-opacity:1;stroke:none;stroke-opacity:1"
+     id="rect4140"
+     width="1"
+     height="5"
+     x="6"
+     y="4" />
+  <rect
+     y="-9"
+     x="6"
+     height="5"
+     width="1"
+     id="rect4142"
+     style="opacity:1;fill:#bebebe;fill-opacity:1;stroke:none;stroke-opacity:1"
+     transform="matrix(0,1,-1,0,0,0)" />
+</svg>

--- a/usr/share/icons/Mint-X/actions/scalable/zoom-original-symbolic.svg
+++ b/usr/share/icons/Mint-X/actions/scalable/zoom-original-symbolic.svg
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg7384"
+   height="16"
+   width="16"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="zoom-original-symbolic.svg">
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1152"
+     inkscape:window-height="715"
+     id="namedview8"
+     showgrid="true"
+     inkscape:zoom="29.5"
+     inkscape:cx="7.6018261"
+     inkscape:cy="8.0438477"
+     inkscape:window-x="680"
+     inkscape:window-y="119"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg7384"
+     inkscape:snap-global="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4138" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata90">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Gnome Symbolic Icon Theme</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <title
+     id="title9167">Gnome Symbolic Icon Theme</title>
+  <g
+     id="layer11"
+     transform="translate(-41 -667)">
+    <path
+       id="path5254"
+       style="block-progression:tb;text-indent:0;color:#000000;enable-background:new;text-transform:none;fill:#bebebe"
+       d="m47.508 668c-3.0289 0-5.5107 2.479-5.5107 5.5045 0 3.0254 2.4819 5.5045 5.5107 5.5045 3.0289 0 5.5107-2.479 5.5107-5.5045 0-3.0254-2.4819-5.5045-5.5107-5.5045zm0 2.0089c1.9474 0 3.4995 1.5504 3.4995 3.4955s-1.5522 3.4955-3.4995 3.4955c-1.9474 0-3.4995-1.5504-3.4995-3.4955 0-1.9452 1.5522-3.4955 3.4995-3.4955z" />
+    <path
+       id="path5256"
+       style="block-progression:tb;text-indent:0;color:#000000;enable-background:new;text-transform:none;fill:#bebebe"
+       d="m50.812 676a1.0001 1.0001 0 0 0 -0.5 1.7188l4 4a1.0055 1.0055 0 1 0 1.4062 -1.4375l-4-4a1.0001 1.0001 0 0 0 -0.906 -0.28z" />
+  </g>
+  <g
+     transform="matrix(0.61338037,0,0,0.61338037,1.7499633,0.74399524)"
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:11.25px;line-height:125%;font-family:'Noto Sans';-inkscape-font-specification:'Noto Sans, Bold';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#bebebe;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     id="flowRoot4163">
+    <path
+       d="m 8.6472168,13.410269 -1.6973877,0 0,-4.6472168 0.016479,-0.7635498 0.027466,-0.8349609 Q 6.5708008,7.5875151 6.4060059,7.719351 L 5.4831543,8.4609282 4.6646729,7.4391997 7.2519531,5.3792631 l 1.3952637,0 0,8.0310059 z"
+       style="fill:#bebebe;fill-opacity:1"
+       id="path4176"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/usr/share/icons/Mint-X/actions/scalable/zoom-out-symbolic.svg
+++ b/usr/share/icons/Mint-X/actions/scalable/zoom-out-symbolic.svg
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg7384"
+   height="16"
+   width="16"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="zoom-out-symbolic.svg">
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1152"
+     inkscape:window-height="715"
+     id="namedview8"
+     showgrid="true"
+     inkscape:zoom="29.5"
+     inkscape:cx="8.3007651"
+     inkscape:cy="8.0438477"
+     inkscape:window-x="570"
+     inkscape:window-y="160"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg7384"
+     inkscape:snap-global="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4138" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata90">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Gnome Symbolic Icon Theme</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <title
+     id="title9167">Gnome Symbolic Icon Theme</title>
+  <g
+     id="layer11"
+     transform="translate(-41 -667)">
+    <path
+       id="path5254"
+       style="block-progression:tb;text-indent:0;color:#000000;enable-background:new;text-transform:none;fill:#bebebe"
+       d="m47.508 668c-3.0289 0-5.5107 2.479-5.5107 5.5045 0 3.0254 2.4819 5.5045 5.5107 5.5045 3.0289 0 5.5107-2.479 5.5107-5.5045 0-3.0254-2.4819-5.5045-5.5107-5.5045zm0 2.0089c1.9474 0 3.4995 1.5504 3.4995 3.4955s-1.5522 3.4955-3.4995 3.4955c-1.9474 0-3.4995-1.5504-3.4995-3.4955 0-1.9452 1.5522-3.4955 3.4995-3.4955z" />
+    <path
+       id="path5256"
+       style="block-progression:tb;text-indent:0;color:#000000;enable-background:new;text-transform:none;fill:#bebebe"
+       d="m50.812 676a1.0001 1.0001 0 0 0 -0.5 1.7188l4 4a1.0055 1.0055 0 1 0 1.4062 -1.4375l-4-4a1.0001 1.0001 0 0 0 -0.906 -0.28z" />
+  </g>
+  <rect
+     y="-9"
+     x="6"
+     height="5"
+     width="1"
+     id="rect4142"
+     style="opacity:1;fill:#bebebe;fill-opacity:1;stroke:none;stroke-opacity:1"
+     transform="matrix(0,1,-1,0,0,0)" />
+</svg>

--- a/usr/share/icons/Mint-X/apps/scalable/help-browser-symbolic.svg
+++ b/usr/share/icons/Mint-X/apps/scalable/help-browser-symbolic.svg
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   id="svg4185"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="help-browser-symbolic.svg">
+  <defs
+     id="defs4187" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="15.839192"
+     inkscape:cx="-5.6087409"
+     inkscape:cy="13.07103"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true"
+     inkscape:bbox-paths="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:snap-global="true"
+     inkscape:window-width="1500"
+     inkscape:window-height="814"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4739" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata4190">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1036.3622)">
+    <path
+       inkscape:connector-curvature="0"
+       style="opacity:1;fill:#bebebe;fill-opacity:1"
+       d="M 7.9999955,1038.3622 A 6.9999959,5.4999796 0 0 0 1,1043.8622 a 6.9999959,5.4999796 0 0 0 3.0273483,4.5275 c 0.0683,0.2081 0.1432499,0.5564 -0.1113301,1.0232 -0.3560896,0.6531 -0.8828092,0.967 -0.8828092,0.967 l -0.0332,0.9823 0.9999994,0 c 0,0 1.4663991,-0.559 1.9667988,-1.0002 0.4214797,-0.3713 0.5372196,-0.9277 0.5722696,-1.1228 a 6.9999959,5.4999796 0 0 0 1.4609287,0.123 6.9999959,5.4999796 0 0 0 6.9999945,-5.5 6.9999959,5.4999796 0 0 0 -6.9999951,-5.5 z m -0.2441399,1.2247 c 0.8249995,0 1.4981291,0.2407 2.0156288,0.7208 0.5249986,0.4796 0.7871086,1.102 0.7871086,1.8669 0,0.4726 -0.09371,0.8625 -0.281251,1.17 -0.187499,0.3074 -0.5433576,0.6462 -1.0683573,1.0138 -0.3374998,0.2399 -0.5483597,0.4297 -0.6308596,0.5722 -0.0825,0.1425 -0.1230498,0.3981 -0.1230498,0.7655 l -1.3964793,0 0,-0.1581 c 0,-0.3748 0.0639,-0.701 0.1913999,-0.9783 0.1349999,-0.2853 0.2968798,-0.5133 0.4843797,-0.6858 0.1874999,-0.1725 0.3749997,-0.3342 0.5624997,-0.4844 0.1874998,-0.15 0.3451598,-0.3225 0.4726597,-0.5175 0.1349999,-0.195 0.2031199,-0.4166 0.2031199,-0.6641 0,-0.3675 -0.11289,-0.6744 -0.3378898,-0.9219 -0.2249999,-0.2476 -0.5062498,-0.3711 -0.8437494,-0.3711 -0.3524999,0 -0.6486697,0.1429 -0.8886695,0.4278 -0.2324996,0.285 -0.3496095,0.6451 -0.3496095,1.0801 l 0,0.1019 0,0.022 -1.529299,0 c 0.007,-0.4876 0.0714,-0.9137 0.1914098,-1.2812 0.1274998,-0.3675 0.2809399,-0.6531 0.4609397,-0.8554 0.1875,-0.21 0.4090598,-0.3784 0.6640596,-0.5062 0.2549999,-0.1274 0.4914793,-0.2104 0.7089792,-0.2477 0.2249999,-0.046 0.4595297,-0.069 0.7070296,-0.069 z m -0.8085895,6.7284 1.687499,0 0,1.6427 -1.687499,0 0,-1.6427 z"
+       id="path4138" />
+  </g>
+</svg>


### PR DESCRIPTION
We want to move the Mint tools to the use of more symbolic icons so they play nicer in a wider variety of themes. Starting adding a few that match the style of the current icons so we aren't always relying on the ones from the gnome theme that don't fit in as well