### PR TITLE
Add missing symbolic links for each extra color theme

### DIFF
--- a/usr/share/icons/Mint-X-Aqua/places/16/folder-videos.svg
+++ b/usr/share/icons/Mint-X-Aqua/places/16/folder-videos.svg
@@ -1,0 +1,1 @@
+folder-video.svg

--- a/usr/share/icons/Mint-X-Blue/places/16/folder-videos.svg
+++ b/usr/share/icons/Mint-X-Blue/places/16/folder-videos.svg
@@ -1,0 +1,1 @@
+folder-video.svg

--- a/usr/share/icons/Mint-X-Brown/places/16/folder-videos.svg
+++ b/usr/share/icons/Mint-X-Brown/places/16/folder-videos.svg
@@ -1,0 +1,1 @@
+folder-video.svg

--- a/usr/share/icons/Mint-X-Grey/places/16/folder-videos.svg
+++ b/usr/share/icons/Mint-X-Grey/places/16/folder-videos.svg
@@ -1,0 +1,1 @@
+folder-video.svg

--- a/usr/share/icons/Mint-X-Orange/places/16/folder-videos.svg
+++ b/usr/share/icons/Mint-X-Orange/places/16/folder-videos.svg
@@ -1,0 +1,1 @@
+folder-video.svg

--- a/usr/share/icons/Mint-X-Pink/places/16/folder-videos.svg
+++ b/usr/share/icons/Mint-X-Pink/places/16/folder-videos.svg
@@ -1,0 +1,1 @@
+folder-video.svg

--- a/usr/share/icons/Mint-X-Purple/places/16/folder-videos.svg
+++ b/usr/share/icons/Mint-X-Purple/places/16/folder-videos.svg
@@ -1,0 +1,1 @@
+folder-video.svg

--- a/usr/share/icons/Mint-X-Red/places/16/folder-videos.svg
+++ b/usr/share/icons/Mint-X-Red/places/16/folder-videos.svg
@@ -1,0 +1,1 @@
+folder-video.svg

--- a/usr/share/icons/Mint-X-Sand/places/16/folder-videos.svg
+++ b/usr/share/icons/Mint-X-Sand/places/16/folder-videos.svg
@@ -1,0 +1,1 @@
+folder-video.svg

--- a/usr/share/icons/Mint-X-Teal/places/16/folder-videos.svg
+++ b/usr/share/icons/Mint-X-Teal/places/16/folder-videos.svg
@@ -1,0 +1,1 @@
+folder-video.svg

--- a/usr/share/icons/Mint-X-Yellow/places/16/folder-videos.svg
+++ b/usr/share/icons/Mint-X-Yellow/places/16/folder-videos.svg
@@ -1,0 +1,1 @@
+folder-video.svg


### PR DESCRIPTION
The necessary symbolic link `places/16/folder-videos.svg` is missing from all extra color themes (`Mint-X-Aqua` etc.). This causes some display issues, see the attached image.

![mint-x-bug](https://cloud.githubusercontent.com/assets/20625037/18810064/5c22c89a-82ae-11e6-927b-e3de27b6cd5b.png)