### PR TITLE
Added size 128 trash icon.

### DIFF
--- a/usr/share/icons/Mint-X/places/128/emptytrash.svg
+++ b/usr/share/icons/Mint-X/places/128/emptytrash.svg
@@ -1,0 +1,1 @@
+user-trash.svg

--- a/usr/share/icons/Mint-X/places/128/gnome-fs-trash-empty.svg
+++ b/usr/share/icons/Mint-X/places/128/gnome-fs-trash-empty.svg
@@ -1,0 +1,1 @@
+user-trash.svg

--- a/usr/share/icons/Mint-X/places/128/gnome-stock-trash.svg
+++ b/usr/share/icons/Mint-X/places/128/gnome-stock-trash.svg
@@ -1,0 +1,1 @@
+user-trash.svg

--- a/usr/share/icons/Mint-X/places/128/trashcan_empty.svg
+++ b/usr/share/icons/Mint-X/places/128/trashcan_empty.svg
@@ -1,0 +1,1 @@
+user-trash.svg

--- a/usr/share/icons/Mint-X/places/128/user-trash.svg
+++ b/usr/share/icons/Mint-X/places/128/user-trash.svg
@@ -1,0 +1,314 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.0"
+   width="128"
+   height="128"
+   id="svg3695"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="user-trash.svg">
+  <metadata
+     id="metadata56">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2955"
+     inkscape:window-height="1776"
+     id="namedview54"
+     showgrid="false"
+     inkscape:zoom="1.84375"
+     inkscape:cx="65.084746"
+     inkscape:cy="64"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3695" />
+  <defs
+     id="defs3697">
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         id="stop5062"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5064"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="62.71241"
+       cy="108.02493"
+       r="47.38271"
+       fx="62.71241"
+       fy="108.02493"
+       id="radialGradient3269"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.3587806,0,0,0.2110472,1.5000008,15.20272)" />
+    <linearGradient
+       id="linearGradient3384">
+      <stop
+         id="stop3386"
+         style="stop-color:#6e6e6e;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3388"
+         style="stop-color:#9f9fa1;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="31.048019"
+       y1="45"
+       x2="31.048019"
+       y2="5.5"
+       id="linearGradient3266"
+       xlink:href="#linearGradient3384"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,2)" />
+    <linearGradient
+       id="linearGradient2793-2-0-403">
+      <stop
+         id="stop4645"
+         style="stop-color:#8d909a;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4647"
+         style="stop-color:#d9d9d9;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="11.93083"
+       y1="26.410894"
+       x2="21.514704"
+       y2="26.410894"
+       id="linearGradient3264"
+       xlink:href="#linearGradient2793-2-0-403"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2083478,0,0,1.5198788,-1.979478,-15.055094)"
+       spreadMethod="reflect" />
+    <radialGradient
+       cx="19.308081"
+       cy="21.029308"
+       r="14.500172"
+       fx="19.308081"
+       fy="21.029308"
+       id="radialGradient3258"
+       xlink:href="#linearGradient3254-8-457"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,1.679283,-1.6454754,0,48.823182,-18.496093)"
+       spreadMethod="pad" />
+    <linearGradient
+       id="linearGradient3355-273">
+      <stop
+         id="stop4657"
+         style="stop-color:#f0f0f0;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3619"
+         style="stop-color:#777779;stop-opacity:1"
+         offset="0.44955608" />
+      <stop
+         id="stop4659"
+         style="stop-color:#6c6c70;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="23.999979"
+       y1="9.3726854"
+       x2="23.999979"
+       y2="2.0968478"
+       id="linearGradient3255"
+       xlink:href="#linearGradient3355-273"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1598658,0,0,1.3742464,-3.8367541,-0.9326014)" />
+    <linearGradient
+       id="linearGradient3320">
+      <stop
+         id="stop3323"
+         style="stop-color:#4e4e4e;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3325"
+         style="stop-color:#b9bac2;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="9.0003471"
+       y1="8"
+       x2="24"
+       y2="8"
+       id="linearGradient3253"
+       xlink:href="#linearGradient3320"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       id="linearGradient3627">
+      <stop
+         id="stop3629"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop3190"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="0.5" />
+      <stop
+         id="stop3631"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="24"
+       cy="7.7919979"
+       r="14.507708"
+       fx="24"
+       fy="7.7919979"
+       id="radialGradient3250"
+       xlink:href="#linearGradient3627"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-3.2042761e-8,0.6892888,-3.1574826,0,48.603098,-13.542931)"
+       spreadMethod="pad" />
+    <linearGradient
+       id="linearGradient3254-8-457">
+      <stop
+         id="stop4669"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4671"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="23.5"
+       y1="10.996204"
+       x2="23.5"
+       y2="39.850574"
+       id="linearGradient3247"
+       xlink:href="#linearGradient3254-8-457"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2227969,0,0,1.9458981,-4.735753,-31.362975)" />
+    <linearGradient
+       id="linearGradient3254-3-182">
+      <stop
+         id="stop4663"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4665"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="12.25"
+       y1="20.230709"
+       x2="17.125"
+       y2="34.173542"
+       id="linearGradient3261"
+       xlink:href="#linearGradient3254-3-182"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8965013,0,0,1.365896,4.7251825,-8.808688)" />
+    <linearGradient
+       x1="24"
+       y1="13.506023"
+       x2="24"
+       y2="43"
+       id="linearGradient3389"
+       xlink:href="#linearGradient3205"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0.3684052,0,1,0,-4.9734702)" />
+    <linearGradient
+       id="linearGradient3205">
+      <stop
+         id="stop3207"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3209"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="24"
+       y1="15.502284"
+       x2="24"
+       y2="45"
+       id="linearGradient3373"
+       xlink:href="#linearGradient3205"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0.04605065,0,1,0,-0.9440383)" />
+  </defs>
+  <g
+     id="layer1"
+     transform="matrix(2.6617647,0,0,2.6617647,0.11764738,-2.0767056)">
+    <path
+       d="M 41,38.001101 C 40.998964,43.52352 33.388109,48 24,48 14.611891,48 7.0010357,43.52352 7,38.001101 6.9989643,32.477823 14.610427,28 24,28 c 9.389573,0 17.001036,4.477823 17,10.001101 z"
+       id="path12941"
+       style="display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient3269);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.05496335;marker:none"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 9.4998277,8 0,32 c 0,2.936408 4.4077703,6.5 14.5001733,6.5 10.092403,0 14.500171,-3.563592 14.500171,-6.5 l 0,-32 c 0,0 -29.0003443,0 -29.0003443,0 z"
+       id="path2230"
+       style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3264);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3266);stroke-width:0.99999994;stroke-opacity:1;marker:none"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 10,9 0,31 c 0,2.822002 6.272,6.000003 14.000001,6 C 31.728001,46 38,42.822002 38,40 L 38,9 C 38,9 10,9 10,9 Z"
+       id="path3212"
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:url(#radialGradient3258);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-opacity:1;marker:none"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 38.507708,8.0000002 c 0,3.0420148 -6.495323,5.5080548 -14.507707,5.5080548 -8.012387,0 -14.5077087,-2.46604 -14.5077087,-5.5080548 0,-3.0420151 6.4953217,-5.5080554 14.5077087,-5.5080554 8.012384,0 14.507707,2.4660403 14.507707,5.5080554 l 0,0 z"
+       id="path3164"
+       style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3253);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3255);stroke-width:0.98388958;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+       inkscape:connector-curvature="0" />
+    <path
+       d="M 38,8.0000002 C 38,10.761424 31.731986,13 24.000001,13 16.268013,13 10,10.761424 10,8.0000002 10,5.2385762 16.268013,2.9999999 24.000001,2.9999999 31.731986,2.9999999 38,5.2385762 38,8.0000002 l 0,0 z"
+       id="path3197"
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient3250);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.98388958;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 10.5,7.8105818 c 0,2.2237962 0,30.5970462 0,32.8246752 0,2.68534 6.075144,4.864745 13.499975,4.864745 7.42483,0 13.500024,-2.179405 13.500024,-4.864745 0,-2.061124 0,-30.7635493 0,-32.8246752 0,-2.2435666 -6.079164,-4.3470216 -13.500024,-4.310103 C 16.579114,3.5373993 10.5,5.5773261 10.5,7.8105818 Z"
+       id="path2206"
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:none;stroke:url(#linearGradient3247);stroke-width:0.99999982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 16.379699,12.177193 4.482507,0.868458 0,33.208353 -4.482507,-1.109791 0,-32.96702 0,0 z"
+       id="rect3244"
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:url(#linearGradient3261);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 13.5,13.506023 c 0.831,0.306145 1.5,1.221608 1.5,2.052608 l 0,26.493977 C 15,42.883608 14.331,43.306145 13.5,43 12.669,42.693855 12,41.778392 12,40.947392 l 0,-26.493977 c 0,-0.831 0.669,-1.253537 1.5,-0.947392 z m 21,-0.246988 C 33.669,13.56518 33,14.480643 33,15.311643 l 0,26.493977 c 0,0.831 0.669,1.253537 1.5,0.947392 0.831,-0.306145 1.5,-1.221608 1.5,-2.052608 l 0,-26.493977 c 0,-0.831 -0.669,-1.253537 -1.5,-0.947392 z"
+       id="path3287"
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#linearGradient3389);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99992186;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;enable-background:accumulate"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 20.5,15.506023 c 0.831,0.03827 1.5,0.738076 1.5,1.569076 l 0,26.493977 C 22,44.400076 21.331,45.038268 20.5,45 19.669,44.961732 19,44.261924 19,43.430924 l 0,-26.493977 c 0,-0.831 0.669,-1.469192 1.5,-1.430924 z m 7,0 c -0.831,0.03827 -1.5,0.738076 -1.5,1.569076 l 0,26.493977 c 0,0.831 0.669,1.469192 1.5,1.430924 0.831,-0.03827 1.5,-0.738076 1.5,-1.569076 l 0,-26.493977 c 0,-0.831 -0.669,-1.469192 -1.5,-1.430924 z"
+       id="path3293"
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#linearGradient3373);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99992186;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;enable-background:accumulate"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/usr/share/icons/Mint-X/places/128/xfce-trash_empty.svg
+++ b/usr/share/icons/Mint-X/places/128/xfce-trash_empty.svg
@@ -1,0 +1,1 @@
+user-trash.svg


### PR DESCRIPTION
Under Linux Mint 18 Cinnamon, the desktop trash icon changes size depending on whether it is empty or full on a hi-DPI display since there's a size 128 trash full icon but no size 128 trash empty icon. This pull request adds the missing trash empty icon (scaled up from the size 48 icon).