### PR TITLE
Add link for new Skype for Linux icons.

### DIFF
--- a/usr/share/icons/Mint-X/apps/16/skypeforlinux.png
+++ b/usr/share/icons/Mint-X/apps/16/skypeforlinux.png
@@ -1,0 +1,1 @@
+skype.png

--- a/usr/share/icons/Mint-X/apps/22/skypeforlinux.png
+++ b/usr/share/icons/Mint-X/apps/22/skypeforlinux.png
@@ -1,0 +1,1 @@
+skype.png

--- a/usr/share/icons/Mint-X/apps/24/skypeforlinux.png
+++ b/usr/share/icons/Mint-X/apps/24/skypeforlinux.png
@@ -1,0 +1,1 @@
+skype.png

--- a/usr/share/icons/Mint-X/apps/32/skypeforlinux.png
+++ b/usr/share/icons/Mint-X/apps/32/skypeforlinux.png
@@ -1,0 +1,1 @@
+skype.png

--- a/usr/share/icons/Mint-X/apps/48/skypeforlinux.png
+++ b/usr/share/icons/Mint-X/apps/48/skypeforlinux.png
@@ -1,0 +1,1 @@
+skype.png

--- a/usr/share/icons/Mint-X/apps/96/skypeforlinux.svg
+++ b/usr/share/icons/Mint-X/apps/96/skypeforlinux.svg
@@ -1,0 +1,1 @@
+skype.svg


### PR DESCRIPTION
**mint-x-icons** | [mint-y-icons](https://github.com/linuxmint/mint-y-icons/pull/19)

The new Skype for Linux Beta uses `skypeforlinux` as the icon name instead of `skype`. This adds a symlink to customize its icon as well.