### PR TITLE
Link minecraft-launcher to minecraft.

### DIFF
--- a/usr/share/icons/Mint-X/apps/32/minecraft-launcher.png
+++ b/usr/share/icons/Mint-X/apps/32/minecraft-launcher.png
@@ -1,0 +1,1 @@
+minecraft.png

--- a/usr/share/icons/Mint-X/apps/48/minecraft-launcher.png
+++ b/usr/share/icons/Mint-X/apps/48/minecraft-launcher.png
@@ -1,0 +1,1 @@
+minecraft.png

--- a/usr/share/icons/Mint-X/apps/96/minecraft-launcher.svg
+++ b/usr/share/icons/Mint-X/apps/96/minecraft-launcher.svg
@@ -1,0 +1,1 @@
+minecraft.svg


### PR DESCRIPTION
`minecraft-launcher` is used for the official Minecraft launcher package, which is currently in testing.