### PR TITLE
Add SVG audio icons for the volume hotkey popup indicator

### DIFF
--- a/usr/share/icons/Mint-X-Dark/index.theme
+++ b/usr/share/icons/Mint-X-Dark/index.theme
@@ -2,7 +2,7 @@
 Name=Mint-X-Dark
 Inherits=Mint-X,Humanity-Dark,ubuntu-mono-dark,gnome
 Comment=Icon theme built for Linux Mint. Uses elements of Faenza and Elementary.
-Directories=actions/16,actions/22,apps/22,places/22,status/22,actions/24,apps/24,places/24,status/24
+Directories=actions/16,actions/22,apps/22,places/22,status/22,actions/24,apps/24,places/24,status/24,status/scalable
 
 Example=directory-x-normal
 
@@ -56,3 +56,9 @@ Size=24
 Context=Status
 Type=fixed
 
+[status/scalable]
+Size=16
+Context=Status
+Type=Scalable
+MinSize=8
+MaxSize=512

--- a/usr/share/icons/Mint-X-Dark/status/scalable/audio-volume-high-panel.svg
+++ b/usr/share/icons/Mint-X-Dark/status/scalable/audio-volume-high-panel.svg
@@ -1,0 +1,1 @@
+../../../Mint-X/status/96/audio-volume-high-panel.svg

--- a/usr/share/icons/Mint-X-Dark/status/scalable/audio-volume-high.svg
+++ b/usr/share/icons/Mint-X-Dark/status/scalable/audio-volume-high.svg
@@ -1,0 +1,1 @@
+../../../Mint-X/status/96/audio-volume-high.svg

--- a/usr/share/icons/Mint-X-Dark/status/scalable/audio-volume-low-panel.svg
+++ b/usr/share/icons/Mint-X-Dark/status/scalable/audio-volume-low-panel.svg
@@ -1,0 +1,1 @@
+../../../Mint-X/status/96/audio-volume-low-panel.svg

--- a/usr/share/icons/Mint-X-Dark/status/scalable/audio-volume-low-zero-panel.svg
+++ b/usr/share/icons/Mint-X-Dark/status/scalable/audio-volume-low-zero-panel.svg
@@ -1,0 +1,1 @@
+../../../Mint-X/status/96/audio-volume-low-zero-panel.svg

--- a/usr/share/icons/Mint-X-Dark/status/scalable/audio-volume-low.svg
+++ b/usr/share/icons/Mint-X-Dark/status/scalable/audio-volume-low.svg
@@ -1,0 +1,1 @@
+../../../Mint-X/status/96/audio-volume-low.svg

--- a/usr/share/icons/Mint-X-Dark/status/scalable/audio-volume-medium-panel.svg
+++ b/usr/share/icons/Mint-X-Dark/status/scalable/audio-volume-medium-panel.svg
@@ -1,0 +1,1 @@
+../../../Mint-X/status/96/audio-volume-medium-panel.svg

--- a/usr/share/icons/Mint-X-Dark/status/scalable/audio-volume-medium.svg
+++ b/usr/share/icons/Mint-X-Dark/status/scalable/audio-volume-medium.svg
@@ -1,0 +1,1 @@
+../../../Mint-X/status/96/audio-volume-medium.svg

--- a/usr/share/icons/Mint-X-Dark/status/scalable/audio-volume-muted-blocked-panel.svg
+++ b/usr/share/icons/Mint-X-Dark/status/scalable/audio-volume-muted-blocked-panel.svg
@@ -1,0 +1,1 @@
+../../../Mint-X/status/96/audio-volume-muted-blocked-panel.svg

--- a/usr/share/icons/Mint-X-Dark/status/scalable/audio-volume-muted-blocking-panel.svg
+++ b/usr/share/icons/Mint-X-Dark/status/scalable/audio-volume-muted-blocking-panel.svg
@@ -1,0 +1,1 @@
+../../../Mint-X/status/96/audio-volume-muted-blocking-panel.svg

--- a/usr/share/icons/Mint-X-Dark/status/scalable/audio-volume-muted-panel.svg
+++ b/usr/share/icons/Mint-X-Dark/status/scalable/audio-volume-muted-panel.svg
@@ -1,0 +1,1 @@
+../../../Mint-X/status/96/audio-volume-muted-panel.svg

--- a/usr/share/icons/Mint-X-Dark/status/scalable/audio-volume-muted.svg
+++ b/usr/share/icons/Mint-X-Dark/status/scalable/audio-volume-muted.svg
@@ -1,0 +1,1 @@
+../../../Mint-X/status/96/audio-volume-muted.svg

--- a/usr/share/icons/Mint-X-Dark/status/scalable/audio-volume-off.svg
+++ b/usr/share/icons/Mint-X-Dark/status/scalable/audio-volume-off.svg
@@ -1,0 +1,1 @@
+../../../Mint-X/status/96/audio-volume-off.svg

--- a/usr/share/icons/Mint-X-Dark/status/scalable/audio-volume-zero-panel.svg
+++ b/usr/share/icons/Mint-X-Dark/status/scalable/audio-volume-zero-panel.svg
@@ -1,0 +1,1 @@
+../../../Mint-X/status/96/audio-volume-zero-panel.svg


### PR DESCRIPTION
These are the same icons as the large volume icons in the base Mint-X theme. These new icons in the Mint-X-Dark theme are just symlinks to the corresponding icons in the Mint-X theme.

----

I use compiz. The `Mint-X-Dark` theme doesn't have high resolution icons for the volume hotkey indicator:

![low-res-cropped](https://user-images.githubusercontent.com/2831985/32206671-bd4d2e76-bdb3-11e7-856c-d5f7f1de82e1.png)

This PR adds the same volume indicator icons from the `Mint-X` theme:

![updated](https://user-images.githubusercontent.com/2831985/32206678-cfc6858e-bdb3-11e7-975d-a3dd7a5f9266.png)
