### PR TITLE
Fix nemo sidebar bookmark icon

### DIFF
--- a/usr/share/icons/Mint-X/places/scalable/inode-directory-symbolic.svg
+++ b/usr/share/icons/Mint-X/places/scalable/inode-directory-symbolic.svg
@@ -1,0 +1,1 @@
+folder-symbolic.svg


### PR DESCRIPTION
The bookmark icon in nemos sidebar changes to an Adwaita/Gnome icon, if you click on a bookmark. Add the missing icon for Mint-X.

Closes https://github.com/linuxmint/nemo/issues/1979