### PR TITLE
Enabled Python icons also for Python3 files

### DIFF
--- a/usr/share/icons/Mint-X/mimetypes/16/text-x-python3.png
+++ b/usr/share/icons/Mint-X/mimetypes/16/text-x-python3.png
@@ -1,0 +1,1 @@
+text-x-python.png

--- a/usr/share/icons/Mint-X/mimetypes/22/text-x-python3.png
+++ b/usr/share/icons/Mint-X/mimetypes/22/text-x-python3.png
@@ -1,0 +1,1 @@
+text-x-python.png

--- a/usr/share/icons/Mint-X/mimetypes/24/text-x-python3.png
+++ b/usr/share/icons/Mint-X/mimetypes/24/text-x-python3.png
@@ -1,0 +1,1 @@
+text-x-python.png

--- a/usr/share/icons/Mint-X/mimetypes/32/text-x-python3.png
+++ b/usr/share/icons/Mint-X/mimetypes/32/text-x-python3.png
@@ -1,0 +1,1 @@
+text-x-python.png

--- a/usr/share/icons/Mint-X/mimetypes/48/text-x-python3.png
+++ b/usr/share/icons/Mint-X/mimetypes/48/text-x-python3.png
@@ -1,0 +1,1 @@
+text-x-python.png

--- a/usr/share/icons/Mint-X/mimetypes/96/text-x-python3.svg
+++ b/usr/share/icons/Mint-X/mimetypes/96/text-x-python3.svg
@@ -1,0 +1,1 @@
+text-x-python.svg


### PR DESCRIPTION
I symlinked the existing Python icon (text-x-python.png) for use with Python3 (text-x-python3.png) as it was also done for Mint-Y icons.