### PR TITLE
Add symlinks for various updated apps

### DIFF
--- a/usr/share/icons/Mint-X/apps/16/display-im6.q16.png
+++ b/usr/share/icons/Mint-X/apps/16/display-im6.q16.png
@@ -1,0 +1,1 @@
+imagemagick.png

--- a/usr/share/icons/Mint-X/apps/16/fr.handbrake.ghb.png
+++ b/usr/share/icons/Mint-X/apps/16/fr.handbrake.ghb.png
@@ -1,0 +1,1 @@
+hb-icon.png

--- a/usr/share/icons/Mint-X/apps/16/io.github.celluloid_player.Celluloid.png
+++ b/usr/share/icons/Mint-X/apps/16/io.github.celluloid_player.Celluloid.png
@@ -1,0 +1,1 @@
+mplayer.png

--- a/usr/share/icons/Mint-X/apps/16/mate-disk-usage-analyzer.png
+++ b/usr/share/icons/Mint-X/apps/16/mate-disk-usage-analyzer.png
@@ -1,0 +1,1 @@
+baobab.png

--- a/usr/share/icons/Mint-X/apps/16/mate-notification-properties.png
+++ b/usr/share/icons/Mint-X/apps/16/mate-notification-properties.png
@@ -1,0 +1,1 @@
+cs-notifications.png

--- a/usr/share/icons/Mint-X/apps/16/mate-power-manager.png
+++ b/usr/share/icons/Mint-X/apps/16/mate-power-manager.png
@@ -1,0 +1,1 @@
+gnome-power-manager.png

--- a/usr/share/icons/Mint-X/apps/16/mate-session-properties.png
+++ b/usr/share/icons/Mint-X/apps/16/mate-session-properties.png
@@ -1,0 +1,1 @@
+gnome-session.png

--- a/usr/share/icons/Mint-X/apps/16/mate-system-log.png
+++ b/usr/share/icons/Mint-X/apps/16/mate-system-log.png
@@ -1,0 +1,1 @@
+logviewer.png

--- a/usr/share/icons/Mint-X/apps/16/menulibre.png
+++ b/usr/share/icons/Mint-X/apps/16/menulibre.png
@@ -1,0 +1,1 @@
+menu-editor.png

--- a/usr/share/icons/Mint-X/apps/16/mozo.png
+++ b/usr/share/icons/Mint-X/apps/16/mozo.png
@@ -1,0 +1,1 @@
+menu-editor.png

--- a/usr/share/icons/Mint-X/apps/16/net.sourceforge.liferea.png
+++ b/usr/share/icons/Mint-X/apps/16/net.sourceforge.liferea.png
@@ -1,0 +1,1 @@
+liferea.png

--- a/usr/share/icons/Mint-X/apps/16/org.gnome.FileRoller.png
+++ b/usr/share/icons/Mint-X/apps/16/org.gnome.FileRoller.png
@@ -1,0 +1,1 @@
+../../mimetypes/16/package-x-generic.png

--- a/usr/share/icons/Mint-X/apps/16/org.gnome.Rhythmbox3.png
+++ b/usr/share/icons/Mint-X/apps/16/org.gnome.Rhythmbox3.png
@@ -1,0 +1,1 @@
+rhythmbox.png

--- a/usr/share/icons/Mint-X/apps/16/org.gnome.SystemMonitor.png
+++ b/usr/share/icons/Mint-X/apps/16/org.gnome.SystemMonitor.png
@@ -1,0 +1,1 @@
+utilities-system-monitor.png

--- a/usr/share/icons/Mint-X/apps/16/org.gnome.Yelp.png
+++ b/usr/share/icons/Mint-X/apps/16/org.gnome.Yelp.png
@@ -1,0 +1,1 @@
+help-browser.png

--- a/usr/share/icons/Mint-X/apps/16/org.inkscape.Inkscape.png
+++ b/usr/share/icons/Mint-X/apps/16/org.inkscape.Inkscape.png
@@ -1,0 +1,1 @@
+inkscape.png

--- a/usr/share/icons/Mint-X/apps/16/xreader.png
+++ b/usr/share/icons/Mint-X/apps/16/xreader.png
@@ -1,0 +1,1 @@
+evince.png

--- a/usr/share/icons/Mint-X/apps/22/display-im6.q16.png
+++ b/usr/share/icons/Mint-X/apps/22/display-im6.q16.png
@@ -1,0 +1,1 @@
+imagemagick.png

--- a/usr/share/icons/Mint-X/apps/22/fr.handbrake.ghb.png
+++ b/usr/share/icons/Mint-X/apps/22/fr.handbrake.ghb.png
@@ -1,0 +1,1 @@
+hb-icon.png

--- a/usr/share/icons/Mint-X/apps/22/io.github.celluloid_player.Celluloid.png
+++ b/usr/share/icons/Mint-X/apps/22/io.github.celluloid_player.Celluloid.png
@@ -1,0 +1,1 @@
+mplayer.png

--- a/usr/share/icons/Mint-X/apps/22/mate-disk-usage-analyzer.png
+++ b/usr/share/icons/Mint-X/apps/22/mate-disk-usage-analyzer.png
@@ -1,0 +1,1 @@
+baobab.png

--- a/usr/share/icons/Mint-X/apps/22/mate-notification-properties.png
+++ b/usr/share/icons/Mint-X/apps/22/mate-notification-properties.png
@@ -1,0 +1,1 @@
+cs-notifications.png

--- a/usr/share/icons/Mint-X/apps/22/mate-power-manager.png
+++ b/usr/share/icons/Mint-X/apps/22/mate-power-manager.png
@@ -1,0 +1,1 @@
+gnome-power-manager.png

--- a/usr/share/icons/Mint-X/apps/22/mate-session-properties.png
+++ b/usr/share/icons/Mint-X/apps/22/mate-session-properties.png
@@ -1,0 +1,1 @@
+gnome-session.png

--- a/usr/share/icons/Mint-X/apps/22/mate-system-log.png
+++ b/usr/share/icons/Mint-X/apps/22/mate-system-log.png
@@ -1,0 +1,1 @@
+logviewer.png

--- a/usr/share/icons/Mint-X/apps/22/menulibre.png
+++ b/usr/share/icons/Mint-X/apps/22/menulibre.png
@@ -1,0 +1,1 @@
+menu-editor.png

--- a/usr/share/icons/Mint-X/apps/22/mozo.png
+++ b/usr/share/icons/Mint-X/apps/22/mozo.png
@@ -1,0 +1,1 @@
+menu-editor.png

--- a/usr/share/icons/Mint-X/apps/22/net.sourceforge.liferea.png
+++ b/usr/share/icons/Mint-X/apps/22/net.sourceforge.liferea.png
@@ -1,0 +1,1 @@
+liferea.png

--- a/usr/share/icons/Mint-X/apps/22/org.gnome.FileRoller.png
+++ b/usr/share/icons/Mint-X/apps/22/org.gnome.FileRoller.png
@@ -1,0 +1,1 @@
+../../mimetypes/22/package-x-generic.png

--- a/usr/share/icons/Mint-X/apps/22/org.gnome.Rhythmbox3.png
+++ b/usr/share/icons/Mint-X/apps/22/org.gnome.Rhythmbox3.png
@@ -1,0 +1,1 @@
+rhythmbox.png

--- a/usr/share/icons/Mint-X/apps/22/org.gnome.SystemMonitor.png
+++ b/usr/share/icons/Mint-X/apps/22/org.gnome.SystemMonitor.png
@@ -1,0 +1,1 @@
+utilities-system-monitor.png

--- a/usr/share/icons/Mint-X/apps/22/org.gnome.Yelp.png
+++ b/usr/share/icons/Mint-X/apps/22/org.gnome.Yelp.png
@@ -1,0 +1,1 @@
+help-browser.png

--- a/usr/share/icons/Mint-X/apps/22/org.inkscape.Inkscape.png
+++ b/usr/share/icons/Mint-X/apps/22/org.inkscape.Inkscape.png
@@ -1,0 +1,1 @@
+inkscape.png

--- a/usr/share/icons/Mint-X/apps/22/xreader.png
+++ b/usr/share/icons/Mint-X/apps/22/xreader.png
@@ -1,0 +1,1 @@
+evince.png

--- a/usr/share/icons/Mint-X/apps/24/display-im6.q16.png
+++ b/usr/share/icons/Mint-X/apps/24/display-im6.q16.png
@@ -1,0 +1,1 @@
+imagemagick.png

--- a/usr/share/icons/Mint-X/apps/24/fr.handbrake.ghb.png
+++ b/usr/share/icons/Mint-X/apps/24/fr.handbrake.ghb.png
@@ -1,0 +1,1 @@
+hb-icon.png

--- a/usr/share/icons/Mint-X/apps/24/io.github.celluloid_player.Celluloid.png
+++ b/usr/share/icons/Mint-X/apps/24/io.github.celluloid_player.Celluloid.png
@@ -1,0 +1,1 @@
+mplayer.png

--- a/usr/share/icons/Mint-X/apps/24/mate-disk-usage-analyzer.png
+++ b/usr/share/icons/Mint-X/apps/24/mate-disk-usage-analyzer.png
@@ -1,0 +1,1 @@
+baobab.png

--- a/usr/share/icons/Mint-X/apps/24/mate-notification-properties.png
+++ b/usr/share/icons/Mint-X/apps/24/mate-notification-properties.png
@@ -1,0 +1,1 @@
+cs-notifications.png

--- a/usr/share/icons/Mint-X/apps/24/mate-power-manager.png
+++ b/usr/share/icons/Mint-X/apps/24/mate-power-manager.png
@@ -1,0 +1,1 @@
+gnome-power-manager.png

--- a/usr/share/icons/Mint-X/apps/24/mate-session-properties.png
+++ b/usr/share/icons/Mint-X/apps/24/mate-session-properties.png
@@ -1,0 +1,1 @@
+gnome-session.png

--- a/usr/share/icons/Mint-X/apps/24/mate-system-log.png
+++ b/usr/share/icons/Mint-X/apps/24/mate-system-log.png
@@ -1,0 +1,1 @@
+logviewer.png

--- a/usr/share/icons/Mint-X/apps/24/menulibre.png
+++ b/usr/share/icons/Mint-X/apps/24/menulibre.png
@@ -1,0 +1,1 @@
+menu-editor.png

--- a/usr/share/icons/Mint-X/apps/24/mozo.png
+++ b/usr/share/icons/Mint-X/apps/24/mozo.png
@@ -1,0 +1,1 @@
+menu-editor.png

--- a/usr/share/icons/Mint-X/apps/24/net.sourceforge.liferea.png
+++ b/usr/share/icons/Mint-X/apps/24/net.sourceforge.liferea.png
@@ -1,0 +1,1 @@
+liferea.png

--- a/usr/share/icons/Mint-X/apps/24/org.gnome.FileRoller.png
+++ b/usr/share/icons/Mint-X/apps/24/org.gnome.FileRoller.png
@@ -1,0 +1,1 @@
+../../mimetypes/24/package-x-generic.png

--- a/usr/share/icons/Mint-X/apps/24/org.gnome.Rhythmbox3.png
+++ b/usr/share/icons/Mint-X/apps/24/org.gnome.Rhythmbox3.png
@@ -1,0 +1,1 @@
+rhythmbox.png

--- a/usr/share/icons/Mint-X/apps/24/org.gnome.SystemMonitor.png
+++ b/usr/share/icons/Mint-X/apps/24/org.gnome.SystemMonitor.png
@@ -1,0 +1,1 @@
+utilities-system-monitor.png

--- a/usr/share/icons/Mint-X/apps/24/org.gnome.Yelp.png
+++ b/usr/share/icons/Mint-X/apps/24/org.gnome.Yelp.png
@@ -1,0 +1,1 @@
+help-browser.png

--- a/usr/share/icons/Mint-X/apps/24/org.inkscape.Inkscape.png
+++ b/usr/share/icons/Mint-X/apps/24/org.inkscape.Inkscape.png
@@ -1,0 +1,1 @@
+inkscape.png

--- a/usr/share/icons/Mint-X/apps/24/xreader.png
+++ b/usr/share/icons/Mint-X/apps/24/xreader.png
@@ -1,0 +1,1 @@
+evince.png

--- a/usr/share/icons/Mint-X/apps/32/display-im6.q16.png
+++ b/usr/share/icons/Mint-X/apps/32/display-im6.q16.png
@@ -1,0 +1,1 @@
+imagemagick.png

--- a/usr/share/icons/Mint-X/apps/32/fr.handbrake.ghb.png
+++ b/usr/share/icons/Mint-X/apps/32/fr.handbrake.ghb.png
@@ -1,0 +1,1 @@
+hb-icon.png

--- a/usr/share/icons/Mint-X/apps/32/io.github.celluloid_player.Celluloid.png
+++ b/usr/share/icons/Mint-X/apps/32/io.github.celluloid_player.Celluloid.png
@@ -1,0 +1,1 @@
+mplayer.png

--- a/usr/share/icons/Mint-X/apps/32/mate-disk-usage-analyzer.png
+++ b/usr/share/icons/Mint-X/apps/32/mate-disk-usage-analyzer.png
@@ -1,0 +1,1 @@
+baobab.png

--- a/usr/share/icons/Mint-X/apps/32/mate-notification-properties.png
+++ b/usr/share/icons/Mint-X/apps/32/mate-notification-properties.png
@@ -1,0 +1,1 @@
+cs-notifications.png

--- a/usr/share/icons/Mint-X/apps/32/mate-power-manager.png
+++ b/usr/share/icons/Mint-X/apps/32/mate-power-manager.png
@@ -1,0 +1,1 @@
+gnome-power-manager.png

--- a/usr/share/icons/Mint-X/apps/32/mate-session-properties.png
+++ b/usr/share/icons/Mint-X/apps/32/mate-session-properties.png
@@ -1,0 +1,1 @@
+gnome-session.png

--- a/usr/share/icons/Mint-X/apps/32/mate-system-log.png
+++ b/usr/share/icons/Mint-X/apps/32/mate-system-log.png
@@ -1,0 +1,1 @@
+logviewer.png

--- a/usr/share/icons/Mint-X/apps/32/menulibre.png
+++ b/usr/share/icons/Mint-X/apps/32/menulibre.png
@@ -1,0 +1,1 @@
+menu-editor.png

--- a/usr/share/icons/Mint-X/apps/32/mozo.png
+++ b/usr/share/icons/Mint-X/apps/32/mozo.png
@@ -1,0 +1,1 @@
+menu-editor.png

--- a/usr/share/icons/Mint-X/apps/32/net.sourceforge.liferea.png
+++ b/usr/share/icons/Mint-X/apps/32/net.sourceforge.liferea.png
@@ -1,0 +1,1 @@
+liferea.png

--- a/usr/share/icons/Mint-X/apps/32/org.gnome.FileRoller.png
+++ b/usr/share/icons/Mint-X/apps/32/org.gnome.FileRoller.png
@@ -1,0 +1,1 @@
+../../mimetypes/32/package-x-generic.png

--- a/usr/share/icons/Mint-X/apps/32/org.gnome.Rhythmbox3.png
+++ b/usr/share/icons/Mint-X/apps/32/org.gnome.Rhythmbox3.png
@@ -1,0 +1,1 @@
+rhythmbox.png

--- a/usr/share/icons/Mint-X/apps/32/org.gnome.SystemMonitor.png
+++ b/usr/share/icons/Mint-X/apps/32/org.gnome.SystemMonitor.png
@@ -1,0 +1,1 @@
+utilities-system-monitor.png

--- a/usr/share/icons/Mint-X/apps/32/org.gnome.Yelp.png
+++ b/usr/share/icons/Mint-X/apps/32/org.gnome.Yelp.png
@@ -1,0 +1,1 @@
+help-browser.png

--- a/usr/share/icons/Mint-X/apps/32/org.inkscape.Inkscape.png
+++ b/usr/share/icons/Mint-X/apps/32/org.inkscape.Inkscape.png
@@ -1,0 +1,1 @@
+inkscape.png

--- a/usr/share/icons/Mint-X/apps/32/xreader.png
+++ b/usr/share/icons/Mint-X/apps/32/xreader.png
@@ -1,0 +1,1 @@
+evince.png

--- a/usr/share/icons/Mint-X/apps/48/display-im6.q16.png
+++ b/usr/share/icons/Mint-X/apps/48/display-im6.q16.png
@@ -1,0 +1,1 @@
+imagemagick.png

--- a/usr/share/icons/Mint-X/apps/48/fr.handbrake.ghb.png
+++ b/usr/share/icons/Mint-X/apps/48/fr.handbrake.ghb.png
@@ -1,0 +1,1 @@
+hb-icon.png

--- a/usr/share/icons/Mint-X/apps/48/io.github.celluloid_player.Celluloid.png
+++ b/usr/share/icons/Mint-X/apps/48/io.github.celluloid_player.Celluloid.png
@@ -1,0 +1,1 @@
+mplayer.png

--- a/usr/share/icons/Mint-X/apps/48/mate-disk-usage-analyzer.png
+++ b/usr/share/icons/Mint-X/apps/48/mate-disk-usage-analyzer.png
@@ -1,0 +1,1 @@
+baobab.png

--- a/usr/share/icons/Mint-X/apps/48/mate-notification-properties.png
+++ b/usr/share/icons/Mint-X/apps/48/mate-notification-properties.png
@@ -1,0 +1,1 @@
+cs-notifications.png

--- a/usr/share/icons/Mint-X/apps/48/mate-power-manager.png
+++ b/usr/share/icons/Mint-X/apps/48/mate-power-manager.png
@@ -1,0 +1,1 @@
+gnome-power-manager.png

--- a/usr/share/icons/Mint-X/apps/48/mate-session-properties.png
+++ b/usr/share/icons/Mint-X/apps/48/mate-session-properties.png
@@ -1,0 +1,1 @@
+gnome-session.png

--- a/usr/share/icons/Mint-X/apps/48/mate-system-log.png
+++ b/usr/share/icons/Mint-X/apps/48/mate-system-log.png
@@ -1,0 +1,1 @@
+logviewer.png

--- a/usr/share/icons/Mint-X/apps/48/menulibre.png
+++ b/usr/share/icons/Mint-X/apps/48/menulibre.png
@@ -1,0 +1,1 @@
+menu-editor.png

--- a/usr/share/icons/Mint-X/apps/48/mozo.png
+++ b/usr/share/icons/Mint-X/apps/48/mozo.png
@@ -1,0 +1,1 @@
+menu-editor.png

--- a/usr/share/icons/Mint-X/apps/48/net.sourceforge.liferea.png
+++ b/usr/share/icons/Mint-X/apps/48/net.sourceforge.liferea.png
@@ -1,0 +1,1 @@
+liferea.png

--- a/usr/share/icons/Mint-X/apps/48/org.gnome.FileRoller.png
+++ b/usr/share/icons/Mint-X/apps/48/org.gnome.FileRoller.png
@@ -1,0 +1,1 @@
+../../mimetypes/48/package-x-generic.png

--- a/usr/share/icons/Mint-X/apps/48/org.gnome.Rhythmbox3.png
+++ b/usr/share/icons/Mint-X/apps/48/org.gnome.Rhythmbox3.png
@@ -1,0 +1,1 @@
+rhythmbox.png

--- a/usr/share/icons/Mint-X/apps/48/org.gnome.SystemMonitor.png
+++ b/usr/share/icons/Mint-X/apps/48/org.gnome.SystemMonitor.png
@@ -1,0 +1,1 @@
+utilities-system-monitor.png

--- a/usr/share/icons/Mint-X/apps/48/org.gnome.Yelp.png
+++ b/usr/share/icons/Mint-X/apps/48/org.gnome.Yelp.png
@@ -1,0 +1,1 @@
+help-browser.png

--- a/usr/share/icons/Mint-X/apps/48/org.inkscape.Inkscape.png
+++ b/usr/share/icons/Mint-X/apps/48/org.inkscape.Inkscape.png
@@ -1,0 +1,1 @@
+inkscape.png

--- a/usr/share/icons/Mint-X/apps/48/xreader.png
+++ b/usr/share/icons/Mint-X/apps/48/xreader.png
@@ -1,0 +1,1 @@
+evince.png

--- a/usr/share/icons/Mint-X/apps/96/display-im6.q16.svg
+++ b/usr/share/icons/Mint-X/apps/96/display-im6.q16.svg
@@ -1,0 +1,1 @@
+imagemagick.svg

--- a/usr/share/icons/Mint-X/apps/96/fr.handbrake.ghb.svg
+++ b/usr/share/icons/Mint-X/apps/96/fr.handbrake.ghb.svg
@@ -1,0 +1,1 @@
+hb-icon.svg

--- a/usr/share/icons/Mint-X/apps/96/io.github.celluloid_player.Celluloid.svg
+++ b/usr/share/icons/Mint-X/apps/96/io.github.celluloid_player.Celluloid.svg
@@ -1,0 +1,1 @@
+mplayer.svg

--- a/usr/share/icons/Mint-X/apps/96/mate-disk-usage-analyzer.svg
+++ b/usr/share/icons/Mint-X/apps/96/mate-disk-usage-analyzer.svg
@@ -1,0 +1,1 @@
+baobab.svg

--- a/usr/share/icons/Mint-X/apps/96/mate-notification-properties.svg
+++ b/usr/share/icons/Mint-X/apps/96/mate-notification-properties.svg
@@ -1,0 +1,1 @@
+cs-notifications.svg

--- a/usr/share/icons/Mint-X/apps/96/mate-power-manager.svg
+++ b/usr/share/icons/Mint-X/apps/96/mate-power-manager.svg
@@ -1,0 +1,1 @@
+gnome-power-manager.svg

--- a/usr/share/icons/Mint-X/apps/96/mate-session-properties.svg
+++ b/usr/share/icons/Mint-X/apps/96/mate-session-properties.svg
@@ -1,0 +1,1 @@
+gnome-session.svg

--- a/usr/share/icons/Mint-X/apps/96/mate-system-log.svg
+++ b/usr/share/icons/Mint-X/apps/96/mate-system-log.svg
@@ -1,0 +1,1 @@
+logviewer.svg

--- a/usr/share/icons/Mint-X/apps/96/menulibre.svg
+++ b/usr/share/icons/Mint-X/apps/96/menulibre.svg
@@ -1,0 +1,1 @@
+menu-editor.svg

--- a/usr/share/icons/Mint-X/apps/96/mozo.svg
+++ b/usr/share/icons/Mint-X/apps/96/mozo.svg
@@ -1,0 +1,1 @@
+menu-editor.svg

--- a/usr/share/icons/Mint-X/apps/96/net.sourceforge.liferea.svg
+++ b/usr/share/icons/Mint-X/apps/96/net.sourceforge.liferea.svg
@@ -1,0 +1,1 @@
+liferea.svg

--- a/usr/share/icons/Mint-X/apps/96/org.gnome.FileRoller.svg
+++ b/usr/share/icons/Mint-X/apps/96/org.gnome.FileRoller.svg
@@ -1,0 +1,1 @@
+../../mimetypes/96/package-x-generic.svg

--- a/usr/share/icons/Mint-X/apps/96/org.gnome.Rhythmbox3.svg
+++ b/usr/share/icons/Mint-X/apps/96/org.gnome.Rhythmbox3.svg
@@ -1,0 +1,1 @@
+rhythmbox.svg

--- a/usr/share/icons/Mint-X/apps/96/org.gnome.SystemMonitor.svg
+++ b/usr/share/icons/Mint-X/apps/96/org.gnome.SystemMonitor.svg
@@ -1,0 +1,1 @@
+utilities-system-monitor.svg

--- a/usr/share/icons/Mint-X/apps/96/org.gnome.Yelp.svg
+++ b/usr/share/icons/Mint-X/apps/96/org.gnome.Yelp.svg
@@ -1,0 +1,1 @@
+help-browser.svg

--- a/usr/share/icons/Mint-X/apps/96/org.inkscape.Inkscape.svg
+++ b/usr/share/icons/Mint-X/apps/96/org.inkscape.Inkscape.svg
@@ -1,0 +1,1 @@
+inkscape.svg

--- a/usr/share/icons/Mint-X/apps/96/xreader.svg
+++ b/usr/share/icons/Mint-X/apps/96/xreader.svg
@@ -1,0 +1,1 @@
+evince.svg


### PR DESCRIPTION
Adds symlinks for Celluloid, FileRoller, GNOME System Monitor, HandBrake, ImageMagick, Inkscape [fixes #196], Liferea, MATE Disk Usage Analyzer, MATE Notification Properties, MATE Power Manager, MATE Session Properties, MATE System Log, Menulibre, Mozo, Rhythmbox, Xreader, and Yelp.
FileRoller and Rhythmbox symlinks are for versions used in LMDE6.