### PR TITLE
Add symlinks for `ungoogled-chromium-browser`

### DIFF
--- a/usr/share/icons/Mint-X/apps/16/ungoogled-chromium-browser.png
+++ b/usr/share/icons/Mint-X/apps/16/ungoogled-chromium-browser.png
@@ -1,0 +1,1 @@
+chromium-browser.png

--- a/usr/share/icons/Mint-X/apps/22/ungoogled-chromium-browser.png
+++ b/usr/share/icons/Mint-X/apps/22/ungoogled-chromium-browser.png
@@ -1,0 +1,1 @@
+chromium-browser.png

--- a/usr/share/icons/Mint-X/apps/24/ungoogled-chromium-browser.png
+++ b/usr/share/icons/Mint-X/apps/24/ungoogled-chromium-browser.png
@@ -1,0 +1,1 @@
+chromium-browser.png

--- a/usr/share/icons/Mint-X/apps/32/ungoogled-chromium-browser.png
+++ b/usr/share/icons/Mint-X/apps/32/ungoogled-chromium-browser.png
@@ -1,0 +1,1 @@
+chromium-browser.png

--- a/usr/share/icons/Mint-X/apps/48/ungoogled-chromium-browser.png
+++ b/usr/share/icons/Mint-X/apps/48/ungoogled-chromium-browser.png
@@ -1,0 +1,1 @@
+chromium-browser.png

--- a/usr/share/icons/Mint-X/apps/96/ungoogled-chromium-browser.svg
+++ b/usr/share/icons/Mint-X/apps/96/ungoogled-chromium-browser.svg
@@ -1,0 +1,1 @@
+chromium-browser.svg


### PR DESCRIPTION
The Gentoo package for ungoogled-chromium recently added separation from the official filenames for Chromium binaries, including icons. This PR adds symlinks from `ungoogled-chromium-browser` to `chromium-browser` to support this change.